### PR TITLE
fix: use changelog as release notes source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,12 @@ jobs:
           path: artifacts
 
       - name: Extract release notes
-        run: awk '/^## \[[0-9]/{if(p) exit; p=1; next} p' crates/cli/CHANGELOG.md > /tmp/release-notes.md
+        run: |
+          if [ -f crates/cli/CHANGELOG.md ]; then
+            awk '/^## \[[0-9]/{if(p) exit; p=1; next} p' crates/cli/CHANGELOG.md > /tmp/release-notes.md
+          else
+            touch /tmp/release-notes.md
+          fi
 
       - name: Create GitHub Release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,8 @@ jobs:
       - name: Extract release notes
         run: |
           if [ -f crates/cli/CHANGELOG.md ]; then
-            awk '/^## \[[0-9]/{if(p) exit; p=1; next} p' crates/cli/CHANGELOG.md > /tmp/release-notes.md
+            version="${GITHUB_REF_NAME#v}"
+            awk "/^## \\[${version}\\]/{if(p) exit; p=1; next} /^## \\[/{if(p) exit} p" crates/cli/CHANGELOG.md > /tmp/release-notes.md
           else
             touch /tmp/release-notes.md
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           TARGET: ${{ matrix.target }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: capsule-${{ matrix.target }}
           path: capsule-${{ github.ref_name }}-${{ matrix.target }}.tar.gz
@@ -67,17 +67,25 @@ jobs:
       contents: write
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Download artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
+
+      - name: Extract release notes
+        run: awk '/^## \[[0-9]/{if(p) exit; p=1; next} p' crates/cli/CHANGELOG.md > /tmp/release-notes.md
 
       - name: Create GitHub Release
         run: |
           gh release create "$TAG_NAME" \
             --repo "$GITHUB_REPOSITORY" \
             --title "$TAG_NAME" \
-            --generate-notes \
+            --notes-file /tmp/release-notes.md \
             "artifacts/capsule-aarch64-apple-darwin/capsule-${TAG_NAME}-aarch64-apple-darwin.tar.gz" \
             "artifacts/capsule-x86_64-unknown-linux-gnu/capsule-${TAG_NAME}-x86_64-unknown-linux-gnu.tar.gz" \
             "artifacts/capsule-aarch64-unknown-linux-gnu/capsule-${TAG_NAME}-aarch64-unknown-linux-gnu.tar.gz"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Generate GitHub App token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
           app-id: ${{ vars.MAINTAIN_APP_ID }}
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Generate GitHub App token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
           app-id: ${{ vars.MAINTAIN_APP_ID }}


### PR DESCRIPTION
## Summary

- Replace `--generate-notes` with content extracted from `crates/cli/CHANGELOG.md` for GitHub Release notes
- Add checkout step to the `release` job so CHANGELOG.md is available at release time
- Update `create-github-app-token` action to v3.0.0

## Test plan

- [ ] Merge a Release PR and verify the GitHub Release notes match the CHANGELOG content