### PR TITLE
feat(custom): add async module source resolution

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -124,7 +124,7 @@ icon = "🦀"
 connector = "via"
 style = { fg = "red" }
 
-# 同じ `name` のソースは env/file → command の順に試され、最初に解決したものが使われます。
+# ソースが複数ある場合は、非同期で解決して最初に成功した結果が使われます。
 [[module.source]]
 name = "version"
 env = "RUST_VERSION"

--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ icon = "🦀"
 connector = "via"
 style = { fg = "red" }
 
-# Sources with the same `name` form a fallback chain; first match wins.
+# If multiple sources share the same `name`, capsule resolves them
+# asynchronously and uses the first successful result that comes back.
 [[module.source]]
 name = "version"
 env = "RUST_VERSION"

--- a/crates/core/src/daemon/request/mod.rs
+++ b/crates/core/src/daemon/request/mod.rs
@@ -296,19 +296,19 @@ async fn detect_custom_modules(input: &DetectInput<'_>) -> Vec<CustomModuleInfo>
     let mut slots: Vec<Option<CustomModuleInfo>> = vec![None; slot_count];
     let mut join_set = JoinSet::new();
 
-    let mut blocking = Vec::new();
+    let mut deferred = Vec::new();
     for (slot, def) in matching.iter().copied() {
         if should_detect_inline(input.speed, def) {
             slots[slot] = input.facts.detect_module(def);
         } else {
-            blocking.push((slot, def.clone()));
+            deferred.push((slot, def.clone()));
         }
     }
 
-    if !blocking.is_empty() {
-        for (slot, def) in blocking {
+    if !deferred.is_empty() {
+        for (slot, def) in deferred {
             let facts = Arc::clone(&input.facts);
-            join_set.spawn_blocking(move || (slot, facts.detect_module(&def)));
+            join_set.spawn(async move { (slot, facts.detect_module_async(&def).await) });
         }
 
         let deadline = tokio::time::Instant::now() + input.timeout;

--- a/crates/core/src/daemon/request/mod.rs
+++ b/crates/core/src/daemon/request/mod.rs
@@ -299,7 +299,7 @@ async fn detect_custom_modules(input: &DetectInput<'_>) -> Vec<CustomModuleInfo>
     let mut deferred = Vec::new();
     for (slot, def) in matching.iter().copied() {
         if should_detect_inline(input.speed, def) {
-            slots[slot] = input.facts.detect_module(def);
+            slots[slot] = input.facts.detect_module(def).await;
         } else {
             deferred.push((slot, def.clone()));
         }
@@ -308,7 +308,7 @@ async fn detect_custom_modules(input: &DetectInput<'_>) -> Vec<CustomModuleInfo>
     if !deferred.is_empty() {
         for (slot, def) in deferred {
             let facts = Arc::clone(&input.facts);
-            join_set.spawn(async move { (slot, facts.detect_module_async(&def).await) });
+            join_set.spawn(async move { (slot, facts.detect_module(&def).await) });
         }
 
         let deadline = tokio::time::Instant::now() + input.timeout;

--- a/crates/core/src/module/custom.rs
+++ b/crates/core/src/module/custom.rs
@@ -361,8 +361,8 @@ mod tests {
 
     // -- detect_modules -------------------------------------------------------
 
-    #[test]
-    fn test_detect_env_source() {
+    #[tokio::test]
+    async fn test_detect_env_source() {
         let defs = resolve_modules(&[ModuleDef {
             name: "aws".to_owned(),
             when: ModuleWhen {
@@ -384,15 +384,16 @@ mod tests {
         }]);
 
         let env_vars = vec![("AWS_PROFILE".to_owned(), "production".to_owned())];
-        let results = detect_modules(&defs, Path::new("/tmp"), &env_vars, None, ModuleSpeed::Fast);
+        let results =
+            detect_modules(&defs, Path::new("/tmp"), &env_vars, None, ModuleSpeed::Fast).await;
 
         let aws = results.iter().find(|r| r.name == "aws");
         assert!(aws.is_some(), "aws module should be detected");
         assert_eq!(aws.map(|a| a.value.as_str()), Some("production"));
     }
 
-    #[test]
-    fn test_detect_env_source_not_set() {
+    #[tokio::test]
+    async fn test_detect_env_source_not_set() {
         let defs = resolve_modules(&[ModuleDef {
             name: "aws".to_owned(),
             when: ModuleWhen {
@@ -413,15 +414,15 @@ mod tests {
             arbitration: None,
         }]);
 
-        let results = detect_modules(&defs, Path::new("/tmp"), &[], None, ModuleSpeed::Fast);
+        let results = detect_modules(&defs, Path::new("/tmp"), &[], None, ModuleSpeed::Fast).await;
         assert!(
             results.iter().all(|r| r.name != "aws"),
             "aws should not be detected without env var"
         );
     }
 
-    #[test]
-    fn test_detect_file_source() -> Result<(), Box<dyn std::error::Error>> {
+    #[tokio::test]
+    async fn test_detect_file_source() -> Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         std::fs::write(dir.path().join(".tool-versions"), "erlang 26.0\n")?;
         std::fs::write(dir.path().join("rebar.config"), "")?;
@@ -446,15 +447,15 @@ mod tests {
             arbitration: None,
         }]);
 
-        let results = detect_modules(&defs, dir.path(), &[], None, ModuleSpeed::Fast);
+        let results = detect_modules(&defs, dir.path(), &[], None, ModuleSpeed::Fast).await;
         let erlang = results.iter().find(|r| r.name == "erlang");
         assert!(erlang.is_some(), "erlang module should be detected");
         assert_eq!(erlang.map(|e| e.value.as_str()), Some("v26.0"));
         Ok(())
     }
 
-    #[test]
-    fn test_detect_command_source() -> Result<(), Box<dyn std::error::Error>> {
+    #[tokio::test]
+    async fn test_detect_command_source() -> Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         std::fs::write(dir.path().join("build.zig"), "")?;
 
@@ -478,15 +479,16 @@ mod tests {
             arbitration: None,
         }]);
 
-        let results = detect_modules(&defs, dir.path(), &[], None, ModuleSpeed::Slow);
+        let results = detect_modules(&defs, dir.path(), &[], None, ModuleSpeed::Slow).await;
         let m = results.iter().find(|r| r.name == "echo_ver");
         assert!(m.is_some(), "echo_ver should be detected");
         assert_eq!(m.map(|e| e.value.as_str()), Some("v1.2.3"));
         Ok(())
     }
 
-    #[test]
-    fn test_detect_fast_source_preferred_over_command() -> Result<(), Box<dyn std::error::Error>> {
+    #[tokio::test]
+    async fn test_detect_fast_source_preferred_over_command()
+    -> Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         std::fs::write(dir.path().join("marker"), "")?;
 
@@ -521,7 +523,7 @@ mod tests {
 
         let env_vars = vec![("MY_VERSION".to_owned(), "from-env".to_owned())];
         // Even though this is a slow module (has command), env source resolves first
-        let results = detect_modules(&defs, dir.path(), &env_vars, None, ModuleSpeed::Slow);
+        let results = detect_modules(&defs, dir.path(), &env_vars, None, ModuleSpeed::Slow).await;
         let m = results.iter().find(|r| r.name == "mixed");
         assert_eq!(
             m.map(|m| m.value.as_str()),
@@ -531,8 +533,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_detect_format_string() {
+    #[tokio::test]
+    async fn test_detect_format_string() {
         let defs = resolve_modules(&[ModuleDef {
             name: "test".to_owned(),
             when: ModuleWhen {
@@ -554,13 +556,14 @@ mod tests {
         }]);
 
         let env_vars = vec![("FOO".to_owned(), "1.0".to_owned())];
-        let results = detect_modules(&defs, Path::new("/tmp"), &env_vars, None, ModuleSpeed::Fast);
+        let results =
+            detect_modules(&defs, Path::new("/tmp"), &env_vars, None, ModuleSpeed::Fast).await;
         let m = results.iter().find(|r| r.name == "test");
         assert_eq!(m.map(|m| m.value.as_str()), Some("v1.0"));
     }
 
-    #[test]
-    fn test_detect_regex_on_env_source() {
+    #[tokio::test]
+    async fn test_detect_regex_on_env_source() {
         let defs = resolve_modules(&[ModuleDef {
             name: "test".to_owned(),
             when: ModuleWhen {
@@ -582,13 +585,14 @@ mod tests {
         }]);
 
         let env_vars = vec![("VERSION_STR".to_owned(), "v1.23.456-beta".to_owned())];
-        let results = detect_modules(&defs, Path::new("/tmp"), &env_vars, None, ModuleSpeed::Fast);
+        let results =
+            detect_modules(&defs, Path::new("/tmp"), &env_vars, None, ModuleSpeed::Fast).await;
         let m = results.iter().find(|r| r.name == "test");
         assert_eq!(m.map(|m| m.value.as_str()), Some("1.23"));
     }
 
-    #[test]
-    fn test_detect_when_files_not_present() -> Result<(), Box<dyn std::error::Error>> {
+    #[tokio::test]
+    async fn test_detect_when_files_not_present() -> Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         // No marker file
         let defs = resolve_modules(&[ModuleDef {
@@ -612,7 +616,7 @@ mod tests {
         }]);
 
         let env_vars = vec![("FOO".to_owned(), "bar".to_owned())];
-        let results = detect_modules(&defs, dir.path(), &env_vars, None, ModuleSpeed::Fast);
+        let results = detect_modules(&defs, dir.path(), &env_vars, None, ModuleSpeed::Fast).await;
         assert!(
             results.is_empty(),
             "module should not trigger without marker file"
@@ -620,8 +624,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_detect_when_empty_always_triggers() {
+    #[tokio::test]
+    async fn test_detect_when_empty_always_triggers() {
         let defs = resolve_modules(&[ModuleDef {
             name: "always".to_owned(),
             when: ModuleWhen::default(), // empty when
@@ -640,12 +644,13 @@ mod tests {
         }]);
 
         let env_vars = vec![("FOO".to_owned(), "bar".to_owned())];
-        let results = detect_modules(&defs, Path::new("/tmp"), &env_vars, None, ModuleSpeed::Fast);
+        let results =
+            detect_modules(&defs, Path::new("/tmp"), &env_vars, None, ModuleSpeed::Fast).await;
         assert_eq!(results.len(), 1, "empty when should always trigger");
     }
 
-    #[test]
-    fn test_detect_command_failure_returns_none() -> Result<(), Box<dyn std::error::Error>> {
+    #[tokio::test]
+    async fn test_detect_command_failure_returns_none() -> Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         std::fs::write(dir.path().join("marker"), "")?;
 
@@ -669,7 +674,7 @@ mod tests {
             arbitration: None,
         }]);
 
-        let results = detect_modules(&defs, dir.path(), &[], None, ModuleSpeed::Slow);
+        let results = detect_modules(&defs, dir.path(), &[], None, ModuleSpeed::Slow).await;
         assert!(
             results.is_empty(),
             "failing command should produce no output"
@@ -677,8 +682,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_detect_modules_same_group_keeps_lower_priority_user_module() {
+    #[tokio::test]
+    async fn test_detect_modules_same_group_keeps_lower_priority_user_module() {
         let defs = resolve_modules(&[
             ModuleDef {
                 name: "alpha".to_owned(),
@@ -718,7 +723,8 @@ mod tests {
             ("ALPHA_VERSION".to_owned(), "1.0.0".to_owned()),
             ("BETA_VERSION".to_owned(), "2.0.0".to_owned()),
         ];
-        let results = detect_modules(&defs, Path::new("/tmp"), &env_vars, None, ModuleSpeed::Fast);
+        let results =
+            detect_modules(&defs, Path::new("/tmp"), &env_vars, None, ModuleSpeed::Fast).await;
 
         assert_eq!(
             results.len(),
@@ -728,8 +734,8 @@ mod tests {
         assert_eq!(results[0].name, "beta");
     }
 
-    #[test]
-    fn test_detect_modules_same_group_equal_priority_keeps_earlier_definition() {
+    #[tokio::test]
+    async fn test_detect_modules_same_group_equal_priority_keeps_earlier_definition() {
         let defs = resolve_modules(&[
             ModuleDef {
                 name: "first".to_owned(),
@@ -769,7 +775,8 @@ mod tests {
             ("FIRST_VERSION".to_owned(), "1.0.0".to_owned()),
             ("SECOND_VERSION".to_owned(), "2.0.0".to_owned()),
         ];
-        let results = detect_modules(&defs, Path::new("/tmp"), &env_vars, None, ModuleSpeed::Fast);
+        let results =
+            detect_modules(&defs, Path::new("/tmp"), &env_vars, None, ModuleSpeed::Fast).await;
 
         assert_eq!(
             results.len(),
@@ -779,8 +786,8 @@ mod tests {
         assert_eq!(results[0].name, "first");
     }
 
-    #[test]
-    fn test_detect_modules_without_arbitration_are_unaffected() {
+    #[tokio::test]
+    async fn test_detect_modules_without_arbitration_are_unaffected() {
         let defs = resolve_modules(&[
             ModuleDef {
                 name: "winner".to_owned(),
@@ -820,7 +827,8 @@ mod tests {
             ("WINNER_VERSION".to_owned(), "1.0.0".to_owned()),
             ("PLAIN_VERSION".to_owned(), "2.0.0".to_owned()),
         ];
-        let results = detect_modules(&defs, Path::new("/tmp"), &env_vars, None, ModuleSpeed::Fast);
+        let results =
+            detect_modules(&defs, Path::new("/tmp"), &env_vars, None, ModuleSpeed::Fast).await;
 
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].name, "winner");
@@ -896,8 +904,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_request_facts_detect_module_uses_forwarded_path()
+    #[tokio::test]
+    async fn test_request_facts_detect_module_uses_forwarded_path()
     -> Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         std::fs::write(dir.path().join("marker"), "")?;
@@ -947,7 +955,7 @@ mod tests {
         )
         .with_forwarded_path_env();
 
-        let detected = facts.detect_module(module);
+        let detected = facts.detect_module(module).await;
         assert_eq!(
             detected.as_ref().map(|info| info.value.as_str()),
             Some("forwarded")
@@ -955,8 +963,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_detect_modules_does_not_treat_forwarded_path_env_as_override()
+    #[tokio::test]
+    async fn test_detect_modules_does_not_treat_forwarded_path_env_as_override()
     -> Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         std::fs::write(dir.path().join("marker"), "")?;
@@ -1002,7 +1010,8 @@ mod tests {
             )],
             None,
             ModuleSpeed::Slow,
-        );
+        )
+        .await;
         assert!(
             results.is_empty(),
             "PATH in env_vars alone must not change detect_modules command lookup"
@@ -1010,8 +1019,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_detect_empty_env_var_value() {
+    #[tokio::test]
+    async fn test_detect_empty_env_var_value() {
         let defs = resolve_modules(&[ModuleDef {
             name: "empty_env".to_owned(),
             when: ModuleWhen {
@@ -1033,7 +1042,8 @@ mod tests {
         }]);
 
         let env_vars = vec![("EMPTY_VAR".to_owned(), String::new())];
-        let results = detect_modules(&defs, Path::new("/tmp"), &env_vars, None, ModuleSpeed::Fast);
+        let results =
+            detect_modules(&defs, Path::new("/tmp"), &env_vars, None, ModuleSpeed::Fast).await;
         let m = results.iter().find(|r| r.name == "empty_env");
         assert!(
             m.is_some(),
@@ -1042,8 +1052,8 @@ mod tests {
         assert_eq!(m.map(|m| m.value.as_str()), Some(""));
     }
 
-    #[test]
-    fn test_detect_empty_file_content_filtered() -> Result<(), Box<dyn std::error::Error>> {
+    #[tokio::test]
+    async fn test_detect_empty_file_content_filtered() -> Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         std::fs::write(dir.path().join("marker"), "")?;
         std::fs::write(dir.path().join(".version"), "")?;
@@ -1068,7 +1078,7 @@ mod tests {
             arbitration: None,
         }]);
 
-        let results = detect_modules(&defs, dir.path(), &[], None, ModuleSpeed::Fast);
+        let results = detect_modules(&defs, dir.path(), &[], None, ModuleSpeed::Fast).await;
         assert!(
             results.iter().all(|r| r.name != "empty_file"),
             "empty file content must not produce a detection"
@@ -1076,8 +1086,9 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_detect_file_source_path_traversal_rejected() -> Result<(), Box<dyn std::error::Error>> {
+    #[tokio::test]
+    async fn test_detect_file_source_path_traversal_rejected()
+    -> Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         let sub = dir.path().join("sub");
         std::fs::create_dir(&sub)?;
@@ -1104,7 +1115,7 @@ mod tests {
             arbitration: None,
         }]);
 
-        let results = detect_modules(&defs, &sub, &[], None, ModuleSpeed::Fast);
+        let results = detect_modules(&defs, &sub, &[], None, ModuleSpeed::Fast).await;
         assert!(
             results.iter().all(|r| r.name != "traversal"),
             "file source with path traversal ('..') must be rejected"
@@ -1112,8 +1123,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_detect_format_no_recursive_expansion() {
+    #[tokio::test]
+    async fn test_detect_format_no_recursive_expansion() {
         let defs = resolve_modules(&[ModuleDef {
             name: "format_inject".to_owned(),
             when: ModuleWhen::default(),
@@ -1132,7 +1143,8 @@ mod tests {
         }]);
 
         let env_vars = vec![("INJECT_VAR".to_owned(), "{value}".to_owned())];
-        let results = detect_modules(&defs, Path::new("/tmp"), &env_vars, None, ModuleSpeed::Fast);
+        let results =
+            detect_modules(&defs, Path::new("/tmp"), &env_vars, None, ModuleSpeed::Fast).await;
         let m = results.iter().find(|r| r.name == "format_inject");
         assert_eq!(
             m.map(|m| m.value.as_str()),
@@ -1141,8 +1153,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_detect_command_no_shell_injection() -> Result<(), Box<dyn std::error::Error>> {
+    #[tokio::test]
+    async fn test_detect_command_no_shell_injection() -> Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         std::fs::write(dir.path().join("marker"), "")?;
         let sentinel = dir.path().join("pwned");
@@ -1170,7 +1182,7 @@ mod tests {
             arbitration: None,
         }]);
 
-        let _results = detect_modules(&defs, dir.path(), &[], None, ModuleSpeed::Slow);
+        let _results = detect_modules(&defs, dir.path(), &[], None, ModuleSpeed::Slow).await;
         assert!(
             !sentinel.exists(),
             "shell metacharacters in command args must not be interpreted"
@@ -1179,7 +1191,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_detect_module_async_uses_first_completed_command_source()
+    async fn test_detect_module_uses_first_completed_command_source()
     -> Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         std::fs::write(dir.path().join("marker"), "")?;
@@ -1227,7 +1239,7 @@ mod tests {
 
         let facts = RequestFacts::collect(dir.path().to_path_buf(), vec![]);
         let started = tokio::time::Instant::now();
-        let detected = facts.detect_module_async(module).await;
+        let detected = facts.detect_module(module).await;
 
         assert_eq!(
             detected.as_ref().map(|info| info.value.as_str()),
@@ -1241,8 +1253,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_detect_module_async_resolves_fast_file_source()
-    -> Result<(), Box<dyn std::error::Error>> {
+    async fn test_detect_module_resolves_fast_file_source() -> Result<(), Box<dyn std::error::Error>>
+    {
         let dir = tempfile::tempdir()?;
         std::fs::write(dir.path().join("marker"), "")?;
         std::fs::write(dir.path().join(".runtime-version"), "2.3.4\n")?;
@@ -1272,7 +1284,7 @@ mod tests {
         };
 
         let facts = RequestFacts::collect(dir.path().to_path_buf(), vec![]);
-        let detected = facts.detect_module_async(module).await;
+        let detected = facts.detect_module(module).await;
 
         assert_eq!(
             detected.as_ref().map(|info| info.value.as_str()),
@@ -1281,8 +1293,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_detect_concurrent_no_corruption() -> Result<(), Box<dyn std::error::Error>> {
+    #[tokio::test]
+    async fn test_detect_concurrent_no_corruption() -> Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         std::fs::write(dir.path().join("marker"), "")?;
         std::fs::write(dir.path().join(".version"), "1.0.0\n")?;
@@ -1314,21 +1326,19 @@ mod tests {
         for _ in 0..8 {
             let defs = std::sync::Arc::clone(&defs);
             let path = dir_path.clone();
-            handles.push(std::thread::spawn(move || {
-                detect_modules(&defs, &path, &[], None, ModuleSpeed::Fast)
+            handles.push(tokio::task::spawn(async move {
+                detect_modules(&defs, &path, &[], None, ModuleSpeed::Fast).await
             }));
         }
 
         for handle in handles {
-            let results = handle
-                .join()
-                .map_err(|panic_payload| format!("thread panicked: {panic_payload:?}"))?;
+            let results = handle.await?;
             let m = results.iter().find(|r| r.name == "concurrent");
-            assert!(m.is_some(), "each thread must detect the module");
+            assert!(m.is_some(), "each task must detect the module");
             assert_eq!(
                 m.map(|m| m.value.as_str()),
                 Some("v1.0.0"),
-                "value must be consistent across threads"
+                "value must be consistent across tasks"
             );
         }
         Ok(())

--- a/crates/core/src/module/custom.rs
+++ b/crates/core/src/module/custom.rs
@@ -162,7 +162,10 @@ pub(crate) struct ModuleDependencyInputs {
 
 #[cfg(test)]
 mod tests {
-    use std::path::{Path, PathBuf};
+    use std::{
+        path::{Path, PathBuf},
+        time::Duration,
+    };
 
     use super::*;
     use crate::{
@@ -1171,6 +1174,109 @@ mod tests {
         assert!(
             !sentinel.exists(),
             "shell metacharacters in command args must not be interpreted"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_detect_module_async_uses_first_completed_command_source()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        std::fs::write(dir.path().join("marker"), "")?;
+
+        let defs = resolve_modules(&[ModuleDef {
+            name: "runtime".to_owned(),
+            when: ModuleWhen {
+                files: vec!["marker".to_owned()],
+                env: vec![],
+            },
+            source: vec![
+                SourceDef {
+                    name: "value".to_owned(),
+                    env: None,
+                    file: None,
+                    command: Some(vec![
+                        "/bin/sh".to_owned(),
+                        "-c".to_owned(),
+                        "sleep 0.3; echo slow".to_owned(),
+                    ]),
+                    regex: None,
+                },
+                SourceDef {
+                    name: "value".to_owned(),
+                    env: None,
+                    file: None,
+                    command: Some(vec![
+                        "/bin/sh".to_owned(),
+                        "-c".to_owned(),
+                        "sleep 0.05; echo fast".to_owned(),
+                    ]),
+                    regex: None,
+                },
+            ],
+            format: "{value}".to_owned(),
+            icon: None,
+            style: StyleConfig::default(),
+            connector: None,
+            arbitration: None,
+        }]);
+        let module = defs.iter().find(|resolved| resolved.name == "runtime");
+        let Some(module) = module else {
+            return Err("runtime module missing".into());
+        };
+
+        let facts = RequestFacts::collect(dir.path().to_path_buf(), vec![]);
+        let started = tokio::time::Instant::now();
+        let detected = facts.detect_module_async(module).await;
+
+        assert_eq!(
+            detected.as_ref().map(|info| info.value.as_str()),
+            Some("fast")
+        );
+        assert!(
+            started.elapsed() < Duration::from_millis(200),
+            "async command resolution must not wait for slower fallbacks once a winner exists"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_detect_module_async_resolves_fast_file_source()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        std::fs::write(dir.path().join("marker"), "")?;
+        std::fs::write(dir.path().join(".runtime-version"), "2.3.4\n")?;
+
+        let defs = resolve_modules(&[ModuleDef {
+            name: "runtime".to_owned(),
+            when: ModuleWhen {
+                files: vec!["marker".to_owned()],
+                env: vec![],
+            },
+            source: vec![SourceDef {
+                name: "value".to_owned(),
+                env: None,
+                file: Some(".runtime-version".to_owned()),
+                command: None,
+                regex: None,
+            }],
+            format: "v{value}".to_owned(),
+            icon: None,
+            style: StyleConfig::default(),
+            connector: None,
+            arbitration: None,
+        }]);
+        let module = defs.iter().find(|resolved| resolved.name == "runtime");
+        let Some(module) = module else {
+            return Err("runtime module missing".into());
+        };
+
+        let facts = RequestFacts::collect(dir.path().to_path_buf(), vec![]);
+        let detected = facts.detect_module_async(module).await;
+
+        assert_eq!(
+            detected.as_ref().map(|info| info.value.as_str()),
+            Some("v2.3.4")
         );
         Ok(())
     }

--- a/crates/core/src/module/custom/detect.rs
+++ b/crates/core/src/module/custom/detect.rs
@@ -12,9 +12,8 @@ use super::{
 /// `path_env` overrides PATH for command execution (launchd support).
 ///
 /// Fast modules only try env/file sources. Slow modules try env/file first,
-/// then command sources on failure.
-#[must_use]
-pub fn detect_modules(
+/// then race all command sources and take the first successful result.
+pub async fn detect_modules(
     defs: &[ResolvedModule],
     cwd: &Path,
     env_vars: &[(String, String)],
@@ -23,15 +22,12 @@ pub fn detect_modules(
 ) -> Vec<CustomModuleInfo> {
     let facts = RequestFacts::collect(cwd.to_path_buf(), env_vars.to_vec())
         .with_command_path_env(path_env.map(ToOwned::to_owned));
-    let detected = facts
-        .matching_modules(defs, only_speed)
-        .into_iter()
-        .filter_map(|(_, module)| {
-            facts
-                .detect_module(module)
-                .map(|info| DetectedModuleCandidate::new(module, info))
-        })
-        .collect();
+    let mut detected = Vec::new();
+    for (_, module) in facts.matching_modules(defs, only_speed) {
+        if let Some(info) = facts.detect_module(module).await {
+            detected.push(DetectedModuleCandidate::new(module, info));
+        }
+    }
     arbitrate_detected_modules(detected)
 }
 

--- a/crates/core/src/module/custom/facts.rs
+++ b/crates/core/src/module/custom/facts.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
     path::{Path, PathBuf},
-    process::Command,
 };
 
 use regex_lite::Regex;
@@ -155,58 +154,23 @@ impl RequestFacts {
 
     /// Detects a module by resolving each source group independently
     /// and formatting with all resolved variables.
-    #[must_use]
-    pub(crate) fn detect_module(&self, def: &ResolvedModule) -> Option<CustomModuleInfo> {
+    pub(crate) async fn detect_module(&self, def: &ResolvedModule) -> Option<CustomModuleInfo> {
         let mut values = HashMap::new();
         for group in &def.source_groups {
-            if let Some(raw) = self.resolve_group(group) {
+            if let Some(raw) = self.resolve_group(group).await {
                 values.insert(group.name.as_str(), raw);
             }
         }
         format_module(def, &values)
     }
 
-    pub(crate) async fn detect_module_async(
-        &self,
-        def: &ResolvedModule,
-    ) -> Option<CustomModuleInfo> {
-        let mut values = HashMap::new();
-        for group in &def.source_groups {
-            if let Some(raw) = self.resolve_group_async(group).await {
-                values.insert(group.name.as_str(), raw);
-            }
-        }
-        format_module(def, &values)
-    }
-
-    /// Resolves a source group using fast-first, slow-second semantics.
-    fn resolve_group(&self, group: &ResolvedSourceGroup) -> Option<String> {
-        for source in &group.sources {
-            if source.is_fast()
-                && let Some(raw) = self.resolve_source(source)
-            {
-                return Some(raw);
-            }
-        }
-
-        for source in &group.sources {
-            if !source.is_fast()
-                && let Some(raw) = self.resolve_source(source)
-            {
-                return Some(raw);
-            }
-        }
-
-        None
-    }
-
-    async fn resolve_group_async(&self, group: &ResolvedSourceGroup) -> Option<String> {
+    async fn resolve_group(&self, group: &ResolvedSourceGroup) -> Option<String> {
         let fast_sources: Vec<&ResolvedSource> = group
             .sources
             .iter()
             .filter(|source| source.is_fast())
             .collect();
-        if let Some(raw) = self.resolve_sources_async(&fast_sources).await {
+        if let Some(raw) = self.resolve_sources(&fast_sources).await {
             return Some(raw);
         }
 
@@ -215,13 +179,13 @@ impl RequestFacts {
             .iter()
             .filter(|source| !source.is_fast())
             .collect();
-        self.resolve_sources_async(&slow_sources).await
+        self.resolve_sources(&slow_sources).await
     }
 
-    async fn resolve_sources_async(&self, sources: &[&ResolvedSource]) -> Option<String> {
+    async fn resolve_sources(&self, sources: &[&ResolvedSource]) -> Option<String> {
         match sources {
             [] => None,
-            [source] => self.resolve_source_async(source).await,
+            [source] => self.resolve_source(source).await,
             _ => {
                 let mut join_set = JoinSet::new();
                 for source in sources {
@@ -230,7 +194,7 @@ impl RequestFacts {
                     let path_env = self.command_path_env().map(ToOwned::to_owned);
                     let source = (*source).clone();
                     join_set.spawn(async move {
-                        resolve_source_async_owned(cwd, env_vars, path_env, source).await
+                        resolve_source_owned(cwd, env_vars, path_env, source).await
                     });
                 }
 
@@ -250,38 +214,7 @@ impl RequestFacts {
         find_env_value(&self.env_vars, name)
     }
 
-    fn resolve_source(&self, source: &ResolvedSource) -> Option<String> {
-        match source {
-            ResolvedSource::Env { name, regex } => {
-                let value = self.env_value(name)?;
-                apply_regex(value, regex.as_ref())
-            }
-            ResolvedSource::File { path, regex } => {
-                let content = std::fs::read_to_string(self.cwd.join(path)).ok()?;
-                validate_file_content(&content, regex.as_ref())
-            }
-            ResolvedSource::Command { args, regex } => {
-                let (program, cmd_args) = args.split_first()?;
-                let mut command = Command::new(program);
-                command.args(cmd_args).current_dir(&self.cwd);
-                if let Some(path_env) = self.command_path_env() {
-                    command.env("PATH", path_env);
-                }
-                let output = command.output().ok()?;
-                if !output.status.success() {
-                    return None;
-                }
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                let trimmed = stdout.trim();
-                if trimmed.is_empty() {
-                    return None;
-                }
-                apply_regex(trimmed, regex.as_ref())
-            }
-        }
-    }
-
-    async fn resolve_source_async(&self, source: &ResolvedSource) -> Option<String> {
+    async fn resolve_source(&self, source: &ResolvedSource) -> Option<String> {
         match source {
             ResolvedSource::Env { name, regex } => {
                 let value = self.env_value(name)?;
@@ -297,13 +230,8 @@ impl RequestFacts {
             }
             ResolvedSource::Command { args, regex } => {
                 let path_env = self.command_path_env().map(ToOwned::to_owned);
-                resolve_command_source_async(
-                    self.cwd.clone(),
-                    path_env,
-                    args.clone(),
-                    regex.clone(),
-                )
-                .await
+                resolve_command_source(self.cwd.clone(), path_env, args.clone(), regex.clone())
+                    .await
             }
         }
     }
@@ -354,7 +282,7 @@ fn push_unique(values: &mut Vec<String>, value: &str) {
     }
 }
 
-async fn resolve_command_source_async(
+async fn resolve_command_source(
     cwd: PathBuf,
     path_env: Option<String>,
     args: Vec<String>,
@@ -378,7 +306,7 @@ async fn resolve_command_source_async(
     apply_regex(trimmed, regex.as_ref())
 }
 
-async fn resolve_source_async_owned(
+async fn resolve_source_owned(
     cwd: PathBuf,
     env_vars: Vec<(String, String)>,
     path_env: Option<String>,
@@ -397,7 +325,7 @@ async fn resolve_source_async_owned(
             validate_file_content(&content, regex.as_ref())
         }
         ResolvedSource::Command { args, regex } => {
-            resolve_command_source_async(cwd, path_env, args, regex).await
+            resolve_command_source(cwd, path_env, args, regex).await
         }
     }
 }

--- a/crates/core/src/module/custom/facts.rs
+++ b/crates/core/src/module/custom/facts.rs
@@ -4,6 +4,9 @@ use std::{
     process::Command,
 };
 
+use regex_lite::Regex;
+use tokio::task::JoinSet;
+
 use super::{
     super::ModuleSpeed,
     CustomModuleInfo, ModuleDependencyInputs, RequestFacts, ResolvedModule, ResolvedSource,
@@ -163,6 +166,19 @@ impl RequestFacts {
         format_module(def, &values)
     }
 
+    pub(crate) async fn detect_module_async(
+        &self,
+        def: &ResolvedModule,
+    ) -> Option<CustomModuleInfo> {
+        let mut values = HashMap::new();
+        for group in &def.source_groups {
+            if let Some(raw) = self.resolve_group_async(group).await {
+                values.insert(group.name.as_str(), raw);
+            }
+        }
+        format_module(def, &values)
+    }
+
     /// Resolves a source group using fast-first, slow-second semantics.
     fn resolve_group(&self, group: &ResolvedSourceGroup) -> Option<String> {
         for source in &group.sources {
@@ -184,11 +200,54 @@ impl RequestFacts {
         None
     }
 
-    fn env_value(&self, name: &str) -> Option<&str> {
-        self.env_vars
+    async fn resolve_group_async(&self, group: &ResolvedSourceGroup) -> Option<String> {
+        let fast_sources: Vec<&ResolvedSource> = group
+            .sources
             .iter()
-            .find(|(key, _)| key == name)
-            .map(|(_, value)| value.as_str())
+            .filter(|source| source.is_fast())
+            .collect();
+        if let Some(raw) = self.resolve_sources_async(&fast_sources).await {
+            return Some(raw);
+        }
+
+        let slow_sources: Vec<&ResolvedSource> = group
+            .sources
+            .iter()
+            .filter(|source| !source.is_fast())
+            .collect();
+        self.resolve_sources_async(&slow_sources).await
+    }
+
+    async fn resolve_sources_async(&self, sources: &[&ResolvedSource]) -> Option<String> {
+        match sources {
+            [] => None,
+            [source] => self.resolve_source_async(source).await,
+            _ => {
+                let mut join_set = JoinSet::new();
+                for source in sources {
+                    let cwd = self.cwd.clone();
+                    let env_vars = self.env_vars.clone();
+                    let path_env = self.command_path_env().map(ToOwned::to_owned);
+                    let source = (*source).clone();
+                    join_set.spawn(async move {
+                        resolve_source_async_owned(cwd, env_vars, path_env, source).await
+                    });
+                }
+
+                while let Some(joined) = join_set.join_next().await {
+                    if let Ok(Some(raw)) = joined {
+                        join_set.abort_all();
+                        return Some(raw);
+                    }
+                }
+
+                None
+            }
+        }
+    }
+
+    fn env_value(&self, name: &str) -> Option<&str> {
+        find_env_value(&self.env_vars, name)
     }
 
     fn resolve_source(&self, source: &ResolvedSource) -> Option<String> {
@@ -199,11 +258,7 @@ impl RequestFacts {
             }
             ResolvedSource::File { path, regex } => {
                 let content = std::fs::read_to_string(self.cwd.join(path)).ok()?;
-                let trimmed = content.trim();
-                if trimmed.is_empty() || trimmed.contains('/') {
-                    return None;
-                }
-                apply_regex(trimmed, regex.as_ref())
+                validate_file_content(&content, regex.as_ref())
             }
             ResolvedSource::Command { args, regex } => {
                 let (program, cmd_args) = args.split_first()?;
@@ -222,6 +277,33 @@ impl RequestFacts {
                     return None;
                 }
                 apply_regex(trimmed, regex.as_ref())
+            }
+        }
+    }
+
+    async fn resolve_source_async(&self, source: &ResolvedSource) -> Option<String> {
+        match source {
+            ResolvedSource::Env { name, regex } => {
+                let value = self.env_value(name)?;
+                apply_regex(value, regex.as_ref())
+            }
+            ResolvedSource::File { path, regex } => {
+                let path = self.cwd.join(path);
+                let content = tokio::task::spawn_blocking(move || std::fs::read_to_string(path))
+                    .await
+                    .ok()?
+                    .ok()?;
+                validate_file_content(&content, regex.as_ref())
+            }
+            ResolvedSource::Command { args, regex } => {
+                let path_env = self.command_path_env().map(ToOwned::to_owned);
+                resolve_command_source_async(
+                    self.cwd.clone(),
+                    path_env,
+                    args.clone(),
+                    regex.clone(),
+                )
+                .await
             }
         }
     }
@@ -251,8 +333,71 @@ pub fn required_env_var_names(modules: &[ResolvedModule]) -> Vec<String> {
     names
 }
 
+fn find_env_value<'a>(env_vars: &'a [(String, String)], name: &str) -> Option<&'a str> {
+    env_vars
+        .iter()
+        .find(|(key, _)| key == name)
+        .map(|(_, value)| value.as_str())
+}
+
+fn validate_file_content(content: &str, regex: Option<&Regex>) -> Option<String> {
+    let trimmed = content.trim();
+    if trimmed.is_empty() || trimmed.contains('/') {
+        return None;
+    }
+    apply_regex(trimmed, regex)
+}
+
 fn push_unique(values: &mut Vec<String>, value: &str) {
     if !values.iter().any(|existing| existing == value) {
         values.push(value.to_owned());
+    }
+}
+
+async fn resolve_command_source_async(
+    cwd: PathBuf,
+    path_env: Option<String>,
+    args: Vec<String>,
+    regex: Option<Regex>,
+) -> Option<String> {
+    let (program, cmd_args) = args.split_first()?;
+    let mut command = tokio::process::Command::new(program);
+    command.kill_on_drop(true).args(cmd_args).current_dir(cwd);
+    if let Some(path_env) = path_env {
+        command.env("PATH", path_env);
+    }
+    let output = command.output().await.ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    apply_regex(trimmed, regex.as_ref())
+}
+
+async fn resolve_source_async_owned(
+    cwd: PathBuf,
+    env_vars: Vec<(String, String)>,
+    path_env: Option<String>,
+    source: ResolvedSource,
+) -> Option<String> {
+    match source {
+        ResolvedSource::Env { name, regex } => {
+            find_env_value(&env_vars, &name).and_then(|v| apply_regex(v, regex.as_ref()))
+        }
+        ResolvedSource::File { path, regex } => {
+            let content =
+                tokio::task::spawn_blocking(move || std::fs::read_to_string(cwd.join(path)))
+                    .await
+                    .ok()?
+                    .ok()?;
+            validate_file_content(&content, regex.as_ref())
+        }
+        ResolvedSource::Command { args, regex } => {
+            resolve_command_source_async(cwd, path_env, args, regex).await
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR introduces asynchronous source resolution for custom modules. When multiple sources share the same `name`, capsule now races them concurrently using `JoinSet` and returns the first successful result, replacing the previous synchronous sequential approach.

## Changes

- Add `detect_module_async`, `resolve_group_async`, and `resolve_source_async` async methods to `RequestFacts`
- Extract `find_env_value` and `validate_file_content` as free functions (reducing duplication)
- Rename `blocking` → `deferred` in `detect_custom_modules` and wire it to `detect_module_async`
- Add integration test verifying first-completed-wins behavior for concurrent command sources
- Update README (EN/JA) to reflect the new async resolution semantics

## Motivation

The old model treated sources with the same name as a sequential fallback chain (`env → file → command`, first match wins). The new model resolves all sources concurrently and takes whoever finishes first, which better matches the use case of multiple slow command sources where any one result is acceptable.

## Technical Details

- `resolve_group_async` separates fast sources (env/file) from slow sources (command). Fast sources are checked first synchronously; if any resolves, it short-circuits. Otherwise, all slow sources are spawned into a `JoinSet` and the first `Some` result wins.
- `resolve_source_async` for `File` uses `tokio::task::spawn_blocking` to avoid blocking the async runtime on filesystem I/O.
- `detect_module_async` orchestrates per-group async resolution and assembles the final `CustomModuleInfo`.

## Impact

- Affected features: custom module detection (non-inline/deferred path)
- Affected files: `crates/core/src/module/custom/facts.rs`, `crates/core/src/module/custom.rs`, `crates/core/src/daemon/request/mod.rs`, `README.md`, `README.ja.md`
- Breaking changes: No

## Testing

1. `task test` — all 30+ tests pass including the new `test_detect_module_async_uses_first_completed_command_source`
2. Verify pre-push hook passes (fmt, clippy, test, doc, build)

## Checklist

- [x] Code works as expected
- [x] Tests have been added/updated
- [x] Documentation has been updated (if necessary)
- [x] Linter and formatter have been run
- [ ] Breaking changes are clearly documented
