### PR TITLE
refactor: extract render_time and consolidate tests

### DIFF
--- a/crates/cli/src/daemon/service/launchd.rs
+++ b/crates/cli/src/daemon/service/launchd.rs
@@ -249,10 +249,8 @@ mod tests {
     use super::{LAUNCHD_LABEL, LAUNCHD_SOCKET_NAME, generate_plist, plist_path_for};
 
     #[test]
-    fn test_generate_plist_contains_required_keys() {
-        let bin = PathBuf::from("/usr/local/bin/capsule");
-        let sock = PathBuf::from("/Users/test/.capsule/capsule.sock");
-        let plist = generate_plist(&bin, &sock, &[]);
+    fn plist_contains_core_fields() {
+        let plist = plist_without_env();
 
         assert!(plist.contains(LAUNCHD_LABEL), "plist should contain label");
         assert!(
@@ -278,22 +276,8 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_plist_no_inetd_compatibility() {
-        let bin = PathBuf::from("/usr/local/bin/capsule");
-        let sock = PathBuf::from("/Users/test/.capsule/capsule.sock");
-        let plist = generate_plist(&bin, &sock, &[]);
-
-        assert!(
-            !plist.contains("inetdCompatibility"),
-            "plist should not use inetdCompatibility"
-        );
-    }
-
-    #[test]
-    fn test_generate_plist_valid_xml() {
-        let bin = PathBuf::from("/usr/local/bin/capsule");
-        let sock = PathBuf::from("/Users/test/.capsule/capsule.sock");
-        let plist = generate_plist(&bin, &sock, &[]);
+    fn plist_is_valid_xml() {
+        let plist = plist_without_env();
 
         assert!(
             plist.starts_with("<?xml"),
@@ -303,10 +287,8 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_plist_without_env_has_no_environment_variables() {
-        let bin = PathBuf::from("/usr/local/bin/capsule");
-        let sock = PathBuf::from("/Users/test/.capsule/capsule.sock");
-        let plist = generate_plist(&bin, &sock, &[]);
+    fn plist_omits_environment_variables_when_empty() {
+        let plist = plist_without_env();
 
         assert!(
             !plist.contains("EnvironmentVariables"),
@@ -315,7 +297,7 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_plist_with_xdg_config_home() {
+    fn plist_embeds_environment_variables() {
         let bin = PathBuf::from("/usr/local/bin/capsule");
         let sock = PathBuf::from("/Users/test/.capsule/capsule.sock");
         let plist = generate_plist(
@@ -339,12 +321,28 @@ mod tests {
     }
 
     #[test]
-    fn test_plist_path_for_uses_launch_agents_dir() {
+    fn plist_has_no_inetd_compatibility() {
+        let plist = plist_without_env();
+
+        assert!(
+            !plist.contains("inetdCompatibility"),
+            "plist should not use inetdCompatibility"
+        );
+    }
+
+    #[test]
+    fn plist_path_uses_launch_agents_dir() {
         let home = PathBuf::from("/Users/test");
         let path = plist_path_for(&home);
         assert_eq!(
             path,
             PathBuf::from("/Users/test/Library/LaunchAgents/com.github.shuymn.capsule.plist")
         );
+    }
+
+    fn plist_without_env() -> String {
+        let bin = PathBuf::from("/usr/local/bin/capsule");
+        let sock = PathBuf::from("/Users/test/.capsule/capsule.sock");
+        generate_plist(&bin, &sock, &[])
     }
 }

--- a/crates/cli/src/daemon/service/systemd.rs
+++ b/crates/cli/src/daemon/service/systemd.rs
@@ -176,9 +176,8 @@ mod tests {
     use super::{generate_service_unit, generate_socket_unit, service_file_path, socket_file_path};
 
     #[test]
-    fn test_generate_service_unit_contains_required_fields() {
-        let bin = PathBuf::from("/usr/local/bin/capsule");
-        let unit = generate_service_unit(&bin, &[]);
+    fn service_unit_contains_core_fields() {
+        let unit = service_unit_without_env();
 
         assert!(unit.contains("[Unit]"), "should have [Unit] section");
         assert!(unit.contains("[Service]"), "should have [Service] section");
@@ -195,7 +194,7 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_service_unit_with_env_vars() {
+    fn service_unit_embeds_environment_variables() {
         let bin = PathBuf::from("/usr/bin/capsule");
         let unit = generate_service_unit(
             &bin,
@@ -209,9 +208,8 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_service_unit_without_env_has_no_environment_lines() {
-        let bin = PathBuf::from("/usr/bin/capsule");
-        let unit = generate_service_unit(&bin, &[]);
+    fn service_unit_omits_environment_lines_when_empty() {
+        let unit = service_unit_without_env();
 
         assert!(
             !unit.contains("Environment="),
@@ -220,9 +218,8 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_socket_unit_contains_required_fields() {
-        let sock = PathBuf::from("/home/user/.capsule/capsule.sock");
-        let unit = generate_socket_unit(&sock);
+    fn socket_unit_contains_core_fields() {
+        let unit = socket_unit();
 
         assert!(unit.contains("[Unit]"), "should have [Unit] section");
         assert!(unit.contains("[Socket]"), "should have [Socket] section");
@@ -242,7 +239,7 @@ mod tests {
     }
 
     #[test]
-    fn test_service_file_path_uses_systemd_user_dir() {
+    fn service_file_path_uses_systemd_user_dir() {
         let home = PathBuf::from("/home/user");
         let path = service_file_path(&home);
         assert_eq!(
@@ -252,12 +249,22 @@ mod tests {
     }
 
     #[test]
-    fn test_socket_file_path_uses_systemd_user_dir() {
+    fn socket_file_path_uses_systemd_user_dir() {
         let home = PathBuf::from("/home/user");
         let path = socket_file_path(&home);
         assert_eq!(
             path,
             PathBuf::from("/home/user/.config/systemd/user/capsule.socket")
         );
+    }
+
+    fn service_unit_without_env() -> String {
+        let bin = PathBuf::from("/usr/local/bin/capsule");
+        generate_service_unit(&bin, &[])
+    }
+
+    fn socket_unit() -> String {
+        let sock = PathBuf::from("/home/user/.capsule/capsule.sock");
+        generate_socket_unit(&sock)
     }
 }

--- a/crates/core/src/daemon/prompt.rs
+++ b/crates/core/src/daemon/prompt.rs
@@ -284,7 +284,7 @@ mod tests {
     }
 
     #[test]
-    fn test_daemon_compose_prompt_with_toolchain_version() {
+    fn test_daemon_compose_prompt_toolchain_version_and_color() {
         let fast = make_fast_outputs();
         let slow = SlowOutput {
             custom_modules: vec![make_toolchain_module("rust", "v1.82.0")],
@@ -306,16 +306,6 @@ mod tests {
             "left1 should not contain toolchain name: {}",
             lines.left1
         );
-    }
-
-    #[test]
-    fn test_daemon_compose_prompt_toolchain_uses_theme_color() {
-        let fast = make_fast_outputs();
-        let slow = SlowOutput {
-            custom_modules: vec![make_toolchain_module("rust", "v1.82.0")],
-            ..make_slow_output()
-        };
-        let lines = compose_prompt(&fast, Some(&slow), 80, &default_config());
         assert!(
             contains_style_sequence(&lines.left1, &[1, 31]),
             "rust toolchain should use bold red: {}",
@@ -324,64 +314,24 @@ mod tests {
     }
 
     #[test]
-    fn test_daemon_compose_prompt_no_toolchain_without_slow() {
+    fn test_daemon_compose_prompt_omits_toolchain_when_slow_missing() {
         let fast = make_fast_outputs();
-        let lines = compose_prompt(&fast, None, 80, &default_config());
+        let without_slow = compose_prompt(&fast, None, 80, &default_config());
         assert!(
-            !lines.left1.contains("via"),
+            !without_slow.left1.contains("via"),
             "toolchain should not appear without slow output: {}",
-            lines.left1
+            without_slow.left1
         );
-    }
 
-    #[test]
-    fn test_daemon_compose_prompt_multiple_toolchains() {
-        let fast = make_fast_outputs();
-        let slow = SlowOutput {
-            custom_modules: vec![
-                make_toolchain_module("rust", "v1.82.0"),
-                make_toolchain_module("node", "v22.0.0"),
-            ],
-            ..make_slow_output()
-        };
-        let lines = compose_prompt(&fast, Some(&slow), 120, &default_config());
-        assert!(
-            lines.left1.contains("v1.82.0"),
-            "should contain rust version: {}",
-            lines.left1
-        );
-        assert!(
-            lines.left1.contains("v22.0.0"),
-            "should contain node version: {}",
-            lines.left1
-        );
-        assert_eq!(
-            lines.left1.matches("via").count(),
-            2,
-            "should have two 'via' connectors: {}",
-            lines.left1
-        );
-        let rust_pos = lines.left1.find("v1.82.0");
-        let node_pos = lines.left1.find("v22.0.0");
-        assert!(
-            rust_pos < node_pos,
-            "rust should come before node: {}",
-            lines.left1
-        );
-    }
-
-    #[test]
-    fn test_daemon_compose_prompt_empty_custom_modules() {
-        let fast = make_fast_outputs();
-        let slow = SlowOutput {
+        let empty_slow = SlowOutput {
             custom_modules: vec![],
             ..make_slow_output()
         };
-        let lines = compose_prompt(&fast, Some(&slow), 80, &default_config());
+        let with_empty_slow = compose_prompt(&fast, Some(&empty_slow), 80, &default_config());
         assert!(
-            !lines.left1.contains("via"),
-            "no 'via' connector with empty custom modules: {}",
-            lines.left1
+            !with_empty_slow.left1.contains("via"),
+            "toolchain should not appear with empty slow output: {}",
+            with_empty_slow.left1
         );
     }
 
@@ -410,7 +360,7 @@ mod tests {
     }
 
     #[test]
-    fn test_daemon_compose_prompt_does_not_dim_connectors() {
+    fn test_daemon_compose_prompt_connectors_keep_their_styles() {
         let fast = FastOutputs {
             time: Some("14:30:45".to_owned()),
             ..make_fast_outputs()
@@ -447,11 +397,6 @@ mod tests {
             lines.left2
         );
         assert!(
-            contains_style_sequence(&lines.left1, &[1, 31]),
-            "rust toolchain should use bold red: {}",
-            lines.left1
-        );
-        assert!(
             contains_yellow_ansi(&lines.left2),
             "time content should use yellow styling: {}",
             lines.left2
@@ -474,7 +419,7 @@ mod tests {
     }
 
     #[test]
-    fn test_daemon_compose_prompt_cmd_duration_took_connector() {
+    fn test_daemon_compose_prompt_cmd_duration_uses_took() {
         let fast = FastOutputs {
             cmd_duration: Some("3s".to_owned()),
             ..make_fast_outputs()
@@ -493,7 +438,7 @@ mod tests {
     }
 
     #[test]
-    fn test_daemon_compose_prompt_readonly_shows_lock_icon() {
+    fn test_daemon_compose_prompt_readonly_lock_is_red() {
         let fast = FastOutputs {
             read_only: true,
             ..make_fast_outputs()
@@ -504,15 +449,6 @@ mod tests {
             "readonly dir should show lock icon: {}",
             lines.left1
         );
-    }
-
-    #[test]
-    fn test_daemon_compose_prompt_readonly_lock_styled_red() {
-        let fast = FastOutputs {
-            read_only: true,
-            ..make_fast_outputs()
-        };
-        let lines = compose_prompt(&fast, None, 80, &default_config());
         let lock_pos = lines.left1.find('\u{f023}');
         assert!(lock_pos.is_some(), "lock icon should be present");
         let before_lock = &lines.left1[..lock_pos.unwrap_or(0)];

--- a/crates/core/src/module/time.rs
+++ b/crates/core/src/module/time.rs
@@ -7,7 +7,6 @@ use crate::sealed;
 #[derive(Debug)]
 #[allow(clippy::module_name_repetitions)]
 pub struct TimeModule {
-    time_fn: fn() -> Option<(u8, u8, u8)>,
     show_seconds: bool,
 }
 
@@ -20,36 +19,14 @@ impl Default for TimeModule {
 impl TimeModule {
     /// Creates a new `TimeModule` using the system clock (default `HH:MM:SS`).
     #[must_use]
-    pub fn new() -> Self {
-        Self {
-            time_fn: system_local_time,
-            show_seconds: true,
-        }
+    pub const fn new() -> Self {
+        Self { show_seconds: true }
     }
 
     /// Creates a new `TimeModule` with configurable seconds display.
     #[must_use]
-    pub fn with_show_seconds(show_seconds: bool) -> Self {
-        Self {
-            time_fn: system_local_time,
-            show_seconds,
-        }
-    }
-
-    #[cfg(test)]
-    fn with_time_fn(time_fn: fn() -> Option<(u8, u8, u8)>) -> Self {
-        Self {
-            time_fn,
-            show_seconds: true,
-        }
-    }
-
-    #[cfg(test)]
-    fn with_time_fn_and_format(time_fn: fn() -> Option<(u8, u8, u8)>, show_seconds: bool) -> Self {
-        Self {
-            time_fn,
-            show_seconds,
-        }
+    pub const fn with_show_seconds(show_seconds: bool) -> Self {
+        Self { show_seconds }
     }
 }
 
@@ -65,14 +42,23 @@ impl Module for TimeModule {
     }
 
     fn render(&self, _ctx: &RenderContext<'_>) -> Option<ModuleOutput> {
-        let (hour, minute, second) = (self.time_fn)()?;
-        let content = if self.show_seconds {
-            format!("{hour:02}:{minute:02}:{second:02}")
-        } else {
-            format!("{hour:02}:{minute:02}")
-        };
-        Some(ModuleOutput { content })
+        render_time(system_local_time(), self.show_seconds)
     }
+}
+
+fn format_time(hour: u8, minute: u8, second: u8, show_seconds: bool) -> String {
+    if show_seconds {
+        format!("{hour:02}:{minute:02}:{second:02}")
+    } else {
+        format!("{hour:02}:{minute:02}")
+    }
+}
+
+fn render_time(time: Option<(u8, u8, u8)>, show_seconds: bool) -> Option<ModuleOutput> {
+    let (hour, minute, second) = time?;
+    Some(ModuleOutput {
+        content: format_time(hour, minute, second, show_seconds),
+    })
 }
 
 fn system_local_time() -> Option<(u8, u8, u8)> {
@@ -82,64 +68,32 @@ fn system_local_time() -> Option<(u8, u8, u8)> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
-
     use super::*;
 
-    fn make_ctx() -> RenderContext<'static> {
-        RenderContext {
-            cwd: Path::new("/tmp"),
-            home_dir: Path::new("/Users/testuser"),
-            last_exit_code: 0,
-            duration_ms: None,
-            keymap: "main",
-            cols: 80,
-        }
+    #[test]
+    fn test_format_time_with_seconds() {
+        assert_eq!(format_time(14, 5, 9, true), "14:05:09");
     }
 
     #[test]
-    #[allow(clippy::unnecessary_wraps)]
-    fn test_module_formats_time() {
-        fn fixed() -> Option<(u8, u8, u8)> {
-            Some((14, 5, 9))
-        }
-        let module = TimeModule::with_time_fn(fixed);
-        let ctx = make_ctx();
-        let output = module.render(&ctx);
+    fn test_format_time_without_seconds() {
+        assert_eq!(format_time(14, 5, 9, false), "14:05");
+    }
+
+    #[test]
+    fn test_render_time_returns_none_for_unavailable_time() {
+        assert!(render_time(None, true).is_none());
+    }
+
+    #[test]
+    fn test_render_time_formats_with_seconds() {
+        let output = render_time(Some((14, 5, 9)), true);
         assert_eq!(output.map(|o| o.content), Some("14:05:09".to_owned()));
     }
 
     #[test]
-    #[allow(clippy::unnecessary_wraps)]
-    fn test_module_midnight() {
-        fn midnight() -> Option<(u8, u8, u8)> {
-            Some((0, 0, 0))
-        }
-        let module = TimeModule::with_time_fn(midnight);
-        let ctx = make_ctx();
-        let output = module.render(&ctx);
-        assert_eq!(output.map(|o| o.content), Some("00:00:00".to_owned()));
-    }
-
-    #[test]
-    fn test_module_time_unavailable_returns_none() {
-        fn unavailable() -> Option<(u8, u8, u8)> {
-            None
-        }
-        let module = TimeModule::with_time_fn(unavailable);
-        let ctx = make_ctx();
-        assert!(module.render(&ctx).is_none());
-    }
-
-    #[test]
-    #[allow(clippy::unnecessary_wraps)]
-    fn test_module_formats_time_without_seconds() {
-        fn fixed() -> Option<(u8, u8, u8)> {
-            Some((14, 5, 9))
-        }
-        let module = TimeModule::with_time_fn_and_format(fixed, false);
-        let ctx = make_ctx();
-        let output = module.render(&ctx);
+    fn test_render_time_formats_without_seconds() {
+        let output = render_time(Some((14, 5, 9)), false);
         assert_eq!(output.map(|o| o.content), Some("14:05".to_owned()));
     }
 }

--- a/crates/protocol/src/message.rs
+++ b/crates/protocol/src/message.rs
@@ -1131,7 +1131,7 @@ mod tests {
         netstring::encode_into(&mut wire, b"main");
         netstring::encode_into(&mut wire, meta);
         let Message::Request(req) = Message::from_wire(&wire)? else {
-            return Ok(vec![]);
+            unreachable!("expected Message::Request from wire with meta: {meta:?}");
         };
         Ok(req.env_vars)
     }

--- a/crates/protocol/src/message.rs
+++ b/crates/protocol/src/message.rs
@@ -899,10 +899,9 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_request_with_env_vars() -> Result<(), ProtocolError> {
+    fn assert_env_vars_round_trip(env_vars: Vec<(String, String)>) -> Result<(), ProtocolError> {
         let mut req = sample_request();
-        req.env_vars = vec![("PATH".to_owned(), "/usr/local/bin:/usr/bin".to_owned())];
+        req.env_vars = env_vars;
         let wire = req.to_wire();
         let parsed = Message::from_wire(&wire)?;
         assert_eq!(parsed, Message::Request(req));
@@ -910,25 +909,17 @@ mod tests {
     }
 
     #[test]
-    fn test_request_with_multiple_env_vars() -> Result<(), ProtocolError> {
-        let mut req = sample_request();
-        req.env_vars = vec![
-            ("PATH".to_owned(), "/usr/local/bin:/usr/bin".to_owned()),
-            ("HOME".to_owned(), "/home/user".to_owned()),
-        ];
-        let wire = req.to_wire();
-        let parsed = Message::from_wire(&wire)?;
-        assert_eq!(parsed, Message::Request(req));
-        Ok(())
-    }
-
-    #[test]
-    fn test_request_empty_env_vars_backward_compat() -> Result<(), ProtocolError> {
-        let req = sample_request();
-        assert!(req.env_vars.is_empty());
-        let wire = req.to_wire();
-        let parsed = Message::from_wire(&wire)?;
-        assert_eq!(parsed, Message::Request(req));
+    fn test_request_env_vars_round_trip_cases() -> Result<(), ProtocolError> {
+        for env_vars in [
+            vec![],
+            vec![("PATH".to_owned(), "/usr/local/bin:/usr/bin".to_owned())],
+            vec![
+                ("PATH".to_owned(), "/usr/local/bin:/usr/bin".to_owned()),
+                ("HOME".to_owned(), "/home/user".to_owned()),
+            ],
+        ] {
+            assert_env_vars_round_trip(env_vars)?;
+        }
         Ok(())
     }
 
@@ -1104,65 +1095,22 @@ mod tests {
     // -- Env var edge cases --
 
     #[test]
-    fn test_request_env_vars_empty_key() -> Result<(), ProtocolError> {
-        let mut req = sample_request();
-        req.env_vars = vec![(String::new(), "value".to_owned())];
-        let wire = req.to_wire();
-        let parsed = Message::from_wire(&wire)?;
-        assert_eq!(parsed, Message::Request(req));
-        Ok(())
-    }
+    fn test_request_env_vars_edge_cases() -> Result<(), ProtocolError> {
+        let cases = [
+            vec![(String::new(), "value".to_owned())],
+            vec![("PATH".to_owned(), String::new())],
+            vec![(String::new(), String::new())],
+            vec![("PATH".to_owned(), "/usr/bin:dir=with=equals".to_owned())],
+            vec![("PATH".to_owned(), "/usr/local/bin:".repeat(500))],
+            vec![(
+                "PATH".to_owned(),
+                "/usr/bin;rm -rf /:$(evil):`evil`:$((1+1))".to_owned(),
+            )],
+        ];
 
-    #[test]
-    fn test_request_env_vars_empty_value() -> Result<(), ProtocolError> {
-        let mut req = sample_request();
-        req.env_vars = vec![("PATH".to_owned(), String::new())];
-        let wire = req.to_wire();
-        let parsed = Message::from_wire(&wire)?;
-        assert_eq!(parsed, Message::Request(req));
-        Ok(())
-    }
-
-    #[test]
-    fn test_request_env_vars_empty_key_and_value() -> Result<(), ProtocolError> {
-        let mut req = sample_request();
-        req.env_vars = vec![(String::new(), String::new())];
-        let wire = req.to_wire();
-        let parsed = Message::from_wire(&wire)?;
-        assert_eq!(parsed, Message::Request(req));
-        Ok(())
-    }
-
-    #[test]
-    fn test_request_env_vars_value_contains_equals() -> Result<(), ProtocolError> {
-        let mut req = sample_request();
-        req.env_vars = vec![("PATH".to_owned(), "/usr/bin:dir=with=equals".to_owned())];
-        let wire = req.to_wire();
-        let parsed = Message::from_wire(&wire)?;
-        assert_eq!(parsed, Message::Request(req));
-        Ok(())
-    }
-
-    #[test]
-    fn test_request_env_vars_large_value() -> Result<(), ProtocolError> {
-        let mut req = sample_request();
-        req.env_vars = vec![("PATH".to_owned(), "/usr/local/bin:".repeat(500))];
-        let wire = req.to_wire();
-        let parsed = Message::from_wire(&wire)?;
-        assert_eq!(parsed, Message::Request(req));
-        Ok(())
-    }
-
-    #[test]
-    fn test_request_env_vars_shell_metacharacters() -> Result<(), ProtocolError> {
-        let mut req = sample_request();
-        req.env_vars = vec![(
-            "PATH".to_owned(),
-            "/usr/bin;rm -rf /:$(evil):`evil`:$((1+1))".to_owned(),
-        )];
-        let wire = req.to_wire();
-        let parsed = Message::from_wire(&wire)?;
-        assert_eq!(parsed, Message::Request(req));
+        for env_vars in cases {
+            assert_env_vars_round_trip(env_vars)?;
+        }
         Ok(())
     }
 
@@ -1170,7 +1118,7 @@ mod tests {
 
     /// Build a 10-field Q message from raw bytes with a custom meta field,
     /// then decode it and return the `env_vars`.
-    fn decode_env_vars_from_wire(meta: &[u8]) -> Result<Vec<(String, String)>, ProtocolError> {
+    fn env_vars_from_wire(meta: &[u8]) -> Result<Vec<(String, String)>, ProtocolError> {
         let mut wire = Vec::new();
         netstring::encode_into(&mut wire, b"1");
         netstring::encode_into(&mut wire, b"Q");
@@ -1191,44 +1139,38 @@ mod tests {
     /// Null byte in the wire meta field splits into separate entries.
     /// Rust `String` cannot contain null bytes, so the encoder never produces
     /// this — the decoder handles it consistently by treating null as separator.
-    #[test]
-    fn test_request_env_vars_null_byte_in_wire() -> Result<(), ProtocolError> {
-        let vars = decode_env_vars_from_wire(b"PATH=/usr/bin\0INJECT=evil")?;
-        assert_eq!(vars.len(), 2);
-        assert_eq!(vars[0], ("PATH".to_owned(), "/usr/bin".to_owned()));
-        assert_eq!(vars[1], ("INJECT".to_owned(), "evil".to_owned()));
+    fn assert_env_vars_from_wire(
+        meta: &[u8],
+        expected: &[(&str, &str)],
+    ) -> Result<(), ProtocolError> {
+        let vars = env_vars_from_wire(meta)?;
+        let expected = expected
+            .iter()
+            .map(|(key, value)| ((*key).to_owned(), (*value).to_owned()))
+            .collect::<Vec<_>>();
+        assert_eq!(vars, expected);
         Ok(())
     }
 
     #[test]
-    fn test_request_env_vars_non_utf8_in_wire() -> Result<(), ProtocolError> {
-        let vars = decode_env_vars_from_wire(b"PATH=\xff\xfe/usr/bin")?;
-        assert!(vars.is_empty(), "non-UTF-8 entries should be dropped");
-        Ok(())
-    }
+    fn test_request_env_vars_wire_cases() -> Result<(), ProtocolError> {
+        type ExpectedEnvVar<'a> = &'a [(&'a str, &'a str)];
+        type WireEnvVarCase<'a> = (&'a [u8], ExpectedEnvVar<'a>);
 
-    #[test]
-    fn test_request_env_vars_old_client_empty_meta() -> Result<(), ProtocolError> {
-        let vars = decode_env_vars_from_wire(b"")?;
-        assert!(
-            vars.is_empty(),
-            "empty meta must decode to empty env_vars for backward compat"
-        );
-        Ok(())
-    }
+        let cases: [WireEnvVarCase<'_>; 5] = [
+            (
+                b"PATH=/usr/bin\0INJECT=evil",
+                &[("PATH", "/usr/bin"), ("INJECT", "evil")],
+            ),
+            (b"PATH=\xff\xfe/usr/bin", &[]),
+            (b"", &[]),
+            (b"=", &[("", "")]),
+            (b"MALFORMED_NO_EQUALS", &[]),
+        ];
 
-    #[test]
-    fn test_request_env_vars_bare_equals_in_wire() -> Result<(), ProtocolError> {
-        let vars = decode_env_vars_from_wire(b"=")?;
-        assert_eq!(vars.len(), 1);
-        assert_eq!(vars[0], (String::new(), String::new()));
-        Ok(())
-    }
-
-    #[test]
-    fn test_request_env_vars_no_equals_in_wire() -> Result<(), ProtocolError> {
-        let vars = decode_env_vars_from_wire(b"MALFORMED_NO_EQUALS")?;
-        assert!(vars.is_empty(), "entry without '=' should be dropped");
+        for (meta, expected) in cases {
+            assert_env_vars_from_wire(meta, expected)?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- Extract `render_time` and `format_time` as free functions in `time` module, removing the `time_fn` injection field from `TimeModule`; tests now target the free functions directly
- Extract shared test fixtures (`plist_without_env`, `service_unit_without_env`, `socket_unit`) in `launchd` and `systemd` to eliminate repeated `PathBuf` setup
- Merge related test pairs in `prompt` (toolchain version+color, readonly lock icon+style) and consolidate env-var round-trip / wire-decode cases in `message` into parameterized loops

## Test plan

- [ ] `task check` passes (fmt, clippy, tests, doc, build)