### PR TITLE
refactor: clean up sync_request and resolve_source APIs

### DIFF
--- a/crates/cli/src/connect.rs
+++ b/crates/cli/src/connect.rs
@@ -21,6 +21,8 @@ use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _};
 
 use crate::daemon::{lock_path, socket_path};
 
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Run the connect relay.
 ///
 /// Auto-starts the daemon if it is not already running, negotiates
@@ -163,7 +165,12 @@ impl BuildIdNegotiation {
 ///
 /// Returns an error if the connection, write, read, or deserialization
 /// fails.
-pub fn sync_request(
+pub fn sync_request(socket_path: &Path, request: &Message) -> anyhow::Result<Message> {
+    sync_request_with_timeout(socket_path, request, DEFAULT_REQUEST_TIMEOUT)
+}
+
+/// Perform a synchronous request-response exchange with a custom timeout.
+pub fn sync_request_with_timeout(
     socket_path: &Path,
     request: &Message,
     timeout: Duration,
@@ -211,7 +218,7 @@ pub fn negotiate_build_id(socket_path: &Path) -> anyhow::Result<BuildIdNegotiati
         build_id: Some(my_build_id.clone()),
     });
 
-    match sync_request(socket_path, &hello, Duration::from_secs(5))? {
+    match sync_request(socket_path, &hello)? {
         Message::HelloAck(ack) => {
             let compatible = ack.build_id.is_none_or(|id| id == my_build_id);
             Ok(if compatible {

--- a/crates/cli/src/daemon/service/mod.rs
+++ b/crates/cli/src/daemon/service/mod.rs
@@ -100,7 +100,7 @@ pub(super) fn wait_until_daemon_ready(
 
     for _ in 0..MAX_ATTEMPTS {
         if let Ok(Message::HelloAck(ack)) =
-            crate::connect::sync_request(socket_path, &hello, ATTEMPT_TIMEOUT)
+            crate::connect::sync_request_with_timeout(socket_path, &hello, ATTEMPT_TIMEOUT)
         {
             let id_ok = match expected_build_id {
                 Some(expected) => ack.build_id.as_ref().is_none_or(|id| id == expected),

--- a/crates/cli/src/daemon/status.rs
+++ b/crates/cli/src/daemon/status.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use capsule_protocol::{Message, PROTOCOL_VERSION, StatusRequest};
 
 use super::socket_path;
@@ -15,7 +13,7 @@ pub fn status(json: bool) -> anyhow::Result<()> {
         version: PROTOCOL_VERSION,
     });
 
-    match crate::connect::sync_request(&sock, &req, Duration::from_secs(5))? {
+    match crate::connect::sync_request(&sock, &req)? {
         Message::StatusResponse(resp) => {
             if json {
                 print_status_json(&resp);

--- a/crates/core/src/module/custom/facts.rs
+++ b/crates/core/src/module/custom/facts.rs
@@ -194,7 +194,7 @@ impl RequestFacts {
                     let path_env = self.command_path_env().map(ToOwned::to_owned);
                     let source = (*source).clone();
                     join_set.spawn(async move {
-                        resolve_source_owned(cwd, env_vars, path_env, source).await
+                        resolve_source_ref(&cwd, &env_vars, path_env.as_deref(), &source).await
                     });
                 }
 
@@ -215,25 +215,7 @@ impl RequestFacts {
     }
 
     async fn resolve_source(&self, source: &ResolvedSource) -> Option<String> {
-        match source {
-            ResolvedSource::Env { name, regex } => {
-                let value = self.env_value(name)?;
-                apply_regex(value, regex.as_ref())
-            }
-            ResolvedSource::File { path, regex } => {
-                let path = self.cwd.join(path);
-                let content = tokio::task::spawn_blocking(move || std::fs::read_to_string(path))
-                    .await
-                    .ok()?
-                    .ok()?;
-                validate_file_content(&content, regex.as_ref())
-            }
-            ResolvedSource::Command { args, regex } => {
-                let path_env = self.command_path_env().map(ToOwned::to_owned);
-                resolve_command_source(self.cwd.clone(), path_env, args.clone(), regex.clone())
-                    .await
-            }
-        }
+        resolve_source_ref(&self.cwd, &self.env_vars, self.command_path_env(), source).await
     }
 }
 
@@ -306,26 +288,32 @@ async fn resolve_command_source(
     apply_regex(trimmed, regex.as_ref())
 }
 
-async fn resolve_source_owned(
-    cwd: PathBuf,
-    env_vars: Vec<(String, String)>,
-    path_env: Option<String>,
-    source: ResolvedSource,
+async fn resolve_source_ref(
+    cwd: &Path,
+    env_vars: &[(String, String)],
+    path_env: Option<&str>,
+    source: &ResolvedSource,
 ) -> Option<String> {
     match source {
         ResolvedSource::Env { name, regex } => {
-            find_env_value(&env_vars, &name).and_then(|v| apply_regex(v, regex.as_ref()))
+            find_env_value(env_vars, name).and_then(|value| apply_regex(value, regex.as_ref()))
         }
         ResolvedSource::File { path, regex } => {
-            let content =
-                tokio::task::spawn_blocking(move || std::fs::read_to_string(cwd.join(path)))
-                    .await
-                    .ok()?
-                    .ok()?;
+            let path = cwd.join(path);
+            let content = tokio::task::spawn_blocking(move || std::fs::read_to_string(path))
+                .await
+                .ok()?
+                .ok()?;
             validate_file_content(&content, regex.as_ref())
         }
         ResolvedSource::Command { args, regex } => {
-            resolve_command_source(cwd, path_env, args, regex).await
+            resolve_command_source(
+                cwd.to_path_buf(),
+                path_env.map(ToOwned::to_owned),
+                args.clone(),
+                regex.clone(),
+            )
+            .await
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add a default-timeout overload of `sync_request`, exposing `sync_request_with_timeout` for callers that need a custom value
- Unify `resolve_source` logic in the custom module by replacing the inlined `resolve_source_owned` (owned values) with a reference-based `resolve_source_ref`

## Changes

**`crates/cli/src/connect.rs`**
- Added `DEFAULT_REQUEST_TIMEOUT` constant (5 s)
- `sync_request(socket_path, request)` is now the default-timeout entry point
- `sync_request_with_timeout(socket_path, request, timeout)` exposed for callers needing a custom timeout

**`crates/cli/src/daemon/service/mod.rs`** / **`daemon/status.rs`**
- Updated call sites: `wait_until_daemon_ready` uses `sync_request_with_timeout`; `status` uses `sync_request`

**`crates/core/src/module/custom/facts.rs`**
- Renamed `resolve_source_owned` → `resolve_source_ref` with `&Path`, `&[(String, String)]`, and `Option<&str>` parameters
- `resolve_source` method now delegates entirely to `resolve_source_ref`, eliminating the duplicate inline `match`

## Test Plan

- [ ] `cargo test --workspace` passes