### PR TITLE
refactor(custom): make command resolver injectable

### DIFF
--- a/crates/core/src/module/custom.rs
+++ b/crates/core/src/module/custom.rs
@@ -9,7 +9,7 @@ mod compile;
 mod detect;
 mod facts;
 
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 pub use builtins::preset_module_defs;
 pub use compile::resolve_modules;
@@ -142,12 +142,13 @@ impl DetectedModuleCandidate {
 
 /// Shared request-derived facts reused across module detection and prompt
 /// rendering.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct RequestFacts {
     cwd: PathBuf,
     env_vars: Vec<(String, String)>,
     path_env: Option<String>,
     read_only: bool,
+    command_resolver: Arc<facts::CommandResolver>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -163,15 +164,41 @@ pub(crate) struct ModuleDependencyInputs {
 #[cfg(test)]
 mod tests {
     use std::{
+        future::pending,
         path::{Path, PathBuf},
+        sync::{Arc, Mutex},
         time::Duration,
     };
+
+    use tokio::sync::oneshot;
 
     use super::*;
     use crate::{
         config::{ModuleDef, RegexPattern, SourceDef, StyleConfig},
         render::style::Color,
     };
+
+    fn mock_command_resolver(
+        fast_rx: Arc<Mutex<Option<oneshot::Receiver<()>>>>,
+    ) -> impl Fn(
+        PathBuf,
+        Option<String>,
+        Vec<String>,
+        Option<regex_lite::Regex>,
+    ) -> facts::CommandResolverFuture {
+        move |_cwd, _path_env, args, _regex| {
+            let is_fast = args.iter().any(|arg| arg.contains("echo fast"));
+            if is_fast {
+                let receiver = fast_rx.lock().ok().and_then(|mut guard| guard.take());
+                Box::pin(async move {
+                    receiver?.await.ok()?;
+                    Some("fast".to_owned())
+                })
+            } else {
+                Box::pin(pending())
+            }
+        }
+    }
 
     fn arbitration(group: &str, priority: u32) -> Arbitration {
         Arbitration {
@@ -1237,17 +1264,25 @@ mod tests {
             return Err("runtime module missing".into());
         };
 
-        let facts = RequestFacts::collect(dir.path().to_path_buf(), vec![]);
-        let started = tokio::time::Instant::now();
-        let detected = facts.detect_module(module).await;
+        let (fast_tx, fast_rx) = oneshot::channel::<()>();
+        let fast_rx = Arc::new(Mutex::new(Some(fast_rx)));
+        let facts = RequestFacts::collect(dir.path().to_path_buf(), vec![])
+            .with_command_resolver(Arc::new(mock_command_resolver(Arc::clone(&fast_rx))));
+
+        let unblock_fast = tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            let _ = fast_tx.send(());
+        });
+        let detected = tokio::time::timeout(Duration::from_secs(1), facts.detect_module(module))
+            .await
+            .map_err(
+                |_elapsed| "detect_module should return after the first successful command source",
+            )?;
+        unblock_fast.await?;
 
         assert_eq!(
             detected.as_ref().map(|info| info.value.as_str()),
             Some("fast")
-        );
-        assert!(
-            started.elapsed() < Duration::from_millis(200),
-            "async command resolution must not wait for slower fallbacks once a winner exists"
         );
         Ok(())
     }

--- a/crates/core/src/module/custom/facts.rs
+++ b/crates/core/src/module/custom/facts.rs
@@ -1,6 +1,9 @@
 use std::{
     collections::{HashMap, HashSet},
+    future::Future,
     path::{Path, PathBuf},
+    pin::Pin,
+    sync::Arc,
 };
 
 use regex_lite::Regex;
@@ -13,6 +16,11 @@ use super::{
     detect::{apply_regex, format_module},
 };
 use crate::config::ModuleWhen;
+
+pub type CommandResolverFuture = Pin<Box<dyn Future<Output = Option<String>> + Send + 'static>>;
+pub type CommandResolver = dyn Fn(PathBuf, Option<String>, Vec<String>, Option<Regex>) -> CommandResolverFuture
+    + Send
+    + Sync;
 
 impl ModuleDependencyInputs {
     fn push_env(&mut self, name: &str) {
@@ -82,6 +90,9 @@ impl RequestFacts {
             env_vars,
             path_env: None,
             read_only,
+            command_resolver: Arc::new(|cwd, path_env, args, regex| {
+                Box::pin(resolve_command_source(cwd, path_env, args, regex))
+            }),
         }
     }
 
@@ -94,6 +105,12 @@ impl RequestFacts {
     #[must_use]
     pub(crate) fn with_forwarded_path_env(mut self) -> Self {
         self.path_env = self.env_value("PATH").map(ToOwned::to_owned);
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_command_resolver(mut self, resolver: Arc<CommandResolver>) -> Self {
+        self.command_resolver = resolver;
         self
     }
 
@@ -192,9 +209,17 @@ impl RequestFacts {
                     let cwd = self.cwd.clone();
                     let env_vars = self.env_vars.clone();
                     let path_env = self.command_path_env().map(ToOwned::to_owned);
+                    let command_resolver = Arc::clone(&self.command_resolver);
                     let source = (*source).clone();
                     join_set.spawn(async move {
-                        resolve_source_ref(&cwd, &env_vars, path_env.as_deref(), &source).await
+                        resolve_source_ref(
+                            &cwd,
+                            &env_vars,
+                            path_env.as_deref(),
+                            &*command_resolver,
+                            &source,
+                        )
+                        .await
                     });
                 }
 
@@ -215,7 +240,25 @@ impl RequestFacts {
     }
 
     async fn resolve_source(&self, source: &ResolvedSource) -> Option<String> {
-        resolve_source_ref(&self.cwd, &self.env_vars, self.command_path_env(), source).await
+        resolve_source_ref(
+            &self.cwd,
+            &self.env_vars,
+            self.command_path_env(),
+            &*self.command_resolver,
+            source,
+        )
+        .await
+    }
+}
+
+impl std::fmt::Debug for RequestFacts {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RequestFacts")
+            .field("cwd", &self.cwd)
+            .field("env_vars", &self.env_vars)
+            .field("path_env", &self.path_env)
+            .field("read_only", &self.read_only)
+            .finish_non_exhaustive()
     }
 }
 
@@ -292,6 +335,7 @@ async fn resolve_source_ref(
     cwd: &Path,
     env_vars: &[(String, String)],
     path_env: Option<&str>,
+    command_resolver: &CommandResolver,
     source: &ResolvedSource,
 ) -> Option<String> {
     match source {
@@ -307,7 +351,7 @@ async fn resolve_source_ref(
             validate_file_content(&content, regex.as_ref())
         }
         ResolvedSource::Command { args, regex } => {
-            resolve_command_source(
+            (command_resolver)(
                 cwd.to_path_buf(),
                 path_env.map(ToOwned::to_owned),
                 args.clone(),


### PR DESCRIPTION
## Summary

- Define `CommandResolver` and `CommandResolverFuture` type aliases in `facts.rs`
- Add `command_resolver: Arc<CommandResolver>` field to `RequestFacts`, defaulting to the real `resolve_command_source` implementation
- Thread `&CommandResolver` through `resolve_source_ref` and all call sites
- Add test-only `with_command_resolver` builder for dependency injection

## Motivation

The existing test for `detect_module` races against real child processes (`sleep 0.05; echo fast` vs `sleep 0.3; echo slow`), making it flaky on slow CI machines and slow to run. By making the command resolver injectable, tests can substitute a mock that controls timing precisely via a `tokio::sync::oneshot` channel — no real processes, no wall-clock sleeps.

## Test plan

- [ ] `cargo test` passes (all 30+ tests green)
- [ ] `cargo clippy` clean (no warnings)
- [ ] Injected mock in `test_detect_module_resolves_fast_command_source` triggers on `oneshot` signal, verifying the resolver returns the first successful result
