### PR TITLE
feat(cli): add --version flag

### DIFF
--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand, ValueEnum};
 
 #[derive(Parser)]
-#[command(name = "capsule", about = "macOS zsh prompt engine")]
+#[command(name = "capsule", about = "macOS zsh prompt engine", version)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Command,

--- a/crates/cli/tests/e2e.rs
+++ b/crates/cli/tests/e2e.rs
@@ -15,6 +15,24 @@ use capsule_protocol::{
 };
 use common::{DaemonProcess, make_request, test_session_id, wait_for_socket_accept};
 
+#[test]
+fn test_version_flag() -> Result<(), Box<dyn std::error::Error>> {
+    let capsule_bin = env!("CARGO_BIN_EXE_capsule");
+    let output = Command::new(capsule_bin).arg("--version").output()?;
+
+    assert!(
+        output.status.success(),
+        "--version should exit successfully"
+    );
+    assert_eq!(std::str::from_utf8(&output.stderr)?, "");
+    assert_eq!(
+        std::str::from_utf8(&output.stdout)?,
+        concat!("capsule ", env!("CARGO_PKG_VERSION"), "\n"),
+    );
+
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // E2E Tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `version` attribute to the clap `#[command]` macro to expose the `--version` flag
- Add `test_version_flag` e2e test verifying the flag exits successfully with correct output format

## Test Plan

- [ ] `cargo test --workspace` passes
- [ ] `capsule --version` prints `capsule <version>` and exits 0 with no stderr output