### PR TITLE
feat(daemon): update service definition on restart

### DIFF
--- a/crates/cli/src/connect.rs
+++ b/crates/cli/src/connect.rs
@@ -237,8 +237,22 @@ pub fn negotiate_build_id(socket_path: &Path) -> anyhow::Result<BuildIdNegotiati
     }
 }
 
-/// Restart the daemon by sending SIGTERM and re-launching.
+/// Restart the daemon, updating the service definition if one is installed.
+///
+/// If a platform service definition (launchd plist / systemd unit) exists,
+/// runs the full install flow to regenerate the definition and restart the
+/// daemon through the service manager. This ensures that binary updates
+/// (e.g. via `brew upgrade`) take effect without requiring a manual
+/// `capsule daemon install`.
+///
+/// Falls back to a manual SIGTERM + re-launch when no service is installed
+/// (standalone mode).
 fn restart_daemon(socket_path: &Path, lock_path: &Path) -> anyhow::Result<()> {
+    let home = crate::daemon::home_dir()?;
+    if crate::daemon::reinstall_service_if_present(&home, socket_path)?.is_some() {
+        return Ok(());
+    }
+
     if let Ok(pid_str) = std::fs::read_to_string(lock_path) {
         let pid_str = pid_str.trim();
         if !pid_str.is_empty() {

--- a/crates/cli/src/daemon.rs
+++ b/crates/cli/src/daemon.rs
@@ -16,11 +16,11 @@ use capsule_core::{
 };
 #[cfg(target_os = "macos")]
 pub use service::Launchd;
-pub use service::ServiceManager;
 #[cfg(target_os = "linux")]
 pub use service::Systemd;
 #[cfg(target_os = "macos")]
 use service::launchd::LAUNCHD_SOCKET_NAME;
+pub use service::{InstallOutcome, ServiceManager, reinstall_service_if_present};
 pub use status::status;
 
 /// Initialize tracing subscriber if `CAPSULE_LOG` is set.
@@ -230,13 +230,15 @@ mod tests {
 
     use capsule_protocol::{BuildId, HelloAck, Message, PROTOCOL_VERSION};
 
-    use super::service::{ServiceManager, daemon_needs_restart, wait_until_daemon_ready};
+    use super::service::{
+        InstallOutcome, ServiceManager, daemon_needs_restart, wait_until_daemon_ready,
+    };
 
     struct NoopServiceManager;
 
     impl ServiceManager for NoopServiceManager {
-        fn install(&self, _home: &Path, _socket_path: &Path) -> anyhow::Result<()> {
-            Ok(())
+        fn install(&self, _home: &Path, _socket_path: &Path) -> anyhow::Result<InstallOutcome> {
+            Ok(InstallOutcome::Installed)
         }
 
         fn uninstall(&self, _home: &Path) -> anyhow::Result<()> {
@@ -333,7 +335,8 @@ mod tests {
     fn test_noop_install() -> Result<(), Box<dyn std::error::Error>> {
         let home = tempfile::tempdir()?;
         let socket = home.path().join("capsule.sock");
-        NoopServiceManager.install(home.path(), &socket)?;
+        let outcome = NoopServiceManager.install(home.path(), &socket)?;
+        assert_eq!(outcome, InstallOutcome::Installed);
         Ok(())
     }
 
@@ -426,6 +429,23 @@ mod tests {
 
         let result = wait_until_daemon_ready(&socket, None);
         assert!(result.is_err(), "should fail on nonexistent socket");
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // reinstall_service_if_present tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_reinstall_returns_none_without_service() -> Result<(), Box<dyn std::error::Error>> {
+        let home = tempfile::tempdir()?;
+        let socket = home.path().join("capsule.sock");
+
+        let result = super::service::reinstall_service_if_present(home.path(), &socket)?;
+        assert!(
+            result.is_none(),
+            "should return None when no service is installed"
+        );
         Ok(())
     }
 }

--- a/crates/cli/src/daemon/service/launchd.rs
+++ b/crates/cli/src/daemon/service/launchd.rs
@@ -81,7 +81,7 @@ impl Launchd {
 
 #[cfg(target_os = "macos")]
 impl ServiceManager for Launchd {
-    fn install(&self, home: &Path, socket_path: &Path) -> anyhow::Result<()> {
+    fn install(&self, home: &Path, socket_path: &Path) -> anyhow::Result<super::InstallOutcome> {
         let capsule_bin = std::env::current_exe().context("cannot find capsule binary")?;
         let forwarded_env = super::collect_forwarded_env();
         let plist_content = generate_plist(&capsule_bin, socket_path, &forwarded_env);
@@ -91,11 +91,9 @@ impl ServiceManager for Launchd {
             if existing == plist_content {
                 if super::daemon_needs_restart(socket_path) {
                     self.restart()?;
-                    println!("daemon restarted (binary updated)");
-                } else {
-                    println!("plist is already current, no reload needed");
+                    return Ok(super::InstallOutcome::Restarted);
                 }
-                return Ok(());
+                return Ok(super::InstallOutcome::AlreadyCurrent);
             }
             let _ = self.unload();
         }
@@ -109,9 +107,8 @@ impl ServiceManager for Launchd {
             .with_context(|| format!("failed to write {}", plist.display()))?;
 
         self.load(&plist)?;
-        println!("capsule daemon installed and loaded");
 
-        Ok(())
+        Ok(super::InstallOutcome::Installed)
     }
 
     fn uninstall(&self, home: &Path) -> anyhow::Result<()> {

--- a/crates/cli/src/daemon/service/mod.rs
+++ b/crates/cli/src/daemon/service/mod.rs
@@ -14,6 +14,18 @@ pub use launchd::Launchd;
 #[cfg(target_os = "linux")]
 pub use systemd::Systemd;
 
+/// Outcome of a [`ServiceManager::install`] operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallOutcome {
+    /// A new service definition was written and the daemon was loaded.
+    Installed,
+    /// The service definition was already current; daemon was restarted
+    /// because the binary was updated.
+    Restarted,
+    /// Everything is already up-to-date; no action was taken.
+    AlreadyCurrent,
+}
+
 /// Abstracts platform-specific service management operations.
 ///
 /// Implementations handle installing, uninstalling, and restarting a daemon
@@ -29,13 +41,13 @@ pub trait ServiceManager {
     /// Idempotent: if the service definition is already current and the
     /// daemon's build ID matches the current binary, no reload occurs.
     ///
-    /// Returns `Ok(())` once the daemon is ready to process requests.
+    /// Returns the [`InstallOutcome`] describing what action was taken.
     ///
     /// # Errors
     ///
     /// Returns an error if the service definition cannot be written or the
     /// service manager operation fails.
-    fn install(&self, home: &Path, socket_path: &Path) -> anyhow::Result<()>;
+    fn install(&self, home: &Path, socket_path: &Path) -> anyhow::Result<InstallOutcome>;
 
     /// Stop the daemon and remove the service definition.
     ///
@@ -54,6 +66,39 @@ pub trait ServiceManager {
     /// Returns an error if the service manager operation fails or the daemon
     /// does not become ready.
     fn restart(&self) -> anyhow::Result<()>;
+}
+
+/// Reinstall the service definition if one is already present.
+///
+/// Checks whether a platform service definition (launchd plist or systemd
+/// unit files) exists. If so, runs the full [`ServiceManager::install`] flow
+/// — which regenerates the definition, reloads it, and restarts the daemon
+/// as needed — then returns the [`InstallOutcome`].
+///
+/// Returns `Ok(None)` if no service definition is installed (i.e. the daemon
+/// runs in standalone mode) or the platform is unsupported.
+///
+/// # Errors
+///
+/// Returns an error if the service reinstall fails.
+pub fn reinstall_service_if_present(
+    home: &Path,
+    socket_path: &Path,
+) -> anyhow::Result<Option<InstallOutcome>> {
+    #[cfg(target_os = "macos")]
+    if launchd::plist_path_for(home).exists() {
+        let sm = Launchd::new(socket_path)?;
+        return Ok(Some(sm.install(home, socket_path)?));
+    }
+
+    #[cfg(target_os = "linux")]
+    if systemd::service_file_path(home).exists() {
+        let sm = Systemd::new(socket_path);
+        return Ok(Some(sm.install(home, socket_path)?));
+    }
+
+    let _ = (home, socket_path);
+    Ok(None)
 }
 
 /// Check if a running daemon needs to be restarted due to a binary update.

--- a/crates/cli/src/daemon/service/systemd.rs
+++ b/crates/cli/src/daemon/service/systemd.rs
@@ -24,7 +24,7 @@ impl Systemd {
 }
 
 impl ServiceManager for Systemd {
-    fn install(&self, home: &Path, socket_path: &Path) -> anyhow::Result<()> {
+    fn install(&self, home: &Path, socket_path: &Path) -> anyhow::Result<super::InstallOutcome> {
         let capsule_bin = std::env::current_exe().context("cannot find capsule binary")?;
         let forwarded_env = super::collect_forwarded_env();
 
@@ -42,11 +42,9 @@ impl ServiceManager for Systemd {
         if service_unchanged && socket_unchanged {
             if super::daemon_needs_restart(&self.socket_path) {
                 self.restart()?;
-                println!("daemon restarted (binary updated)");
-            } else {
-                println!("unit files are already current, no reload needed");
+                return Ok(super::InstallOutcome::Restarted);
             }
-            return Ok(());
+            return Ok(super::InstallOutcome::AlreadyCurrent);
         }
 
         // Stop before rewriting unit files.
@@ -68,8 +66,7 @@ impl ServiceManager for Systemd {
         super::wait_until_daemon_ready(&self.socket_path, None)
             .context("daemon did not become ready after install")?;
 
-        println!("capsule daemon installed and started");
-        Ok(())
+        Ok(super::InstallOutcome::Installed)
     }
 
     fn uninstall(&self, home: &Path) -> anyhow::Result<()> {
@@ -160,7 +157,7 @@ fn unit_dir(home: &Path) -> PathBuf {
 }
 
 /// Path to the `.service` unit file.
-fn service_file_path(home: &Path) -> PathBuf {
+pub(super) fn service_file_path(home: &Path) -> PathBuf {
     unit_dir(home).join("capsule.service")
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> anyhow::Result<()> {
             None => daemon::run(),
             Some(DaemonAction::Status { json }) => daemon::status(json),
             Some(DaemonAction::Install | DaemonAction::Uninstall) => {
-                use daemon::ServiceManager as _;
+                use daemon::{InstallOutcome, ServiceManager as _};
 
                 let home = daemon::home_dir()?;
                 let socket_path = daemon::socket_path()?;
@@ -33,7 +33,21 @@ fn main() -> anyhow::Result<()> {
                 anyhow::bail!("service management is not supported on this platform");
 
                 match action {
-                    Some(DaemonAction::Install) => sm.install(&home, &socket_path),
+                    Some(DaemonAction::Install) => {
+                        let outcome = sm.install(&home, &socket_path)?;
+                        match outcome {
+                            InstallOutcome::Installed => {
+                                println!("capsule daemon installed and loaded");
+                            }
+                            InstallOutcome::Restarted => {
+                                println!("daemon restarted (binary updated)");
+                            }
+                            InstallOutcome::AlreadyCurrent => {
+                                println!("service is already current, no reload needed");
+                            }
+                        }
+                        Ok(())
+                    }
                     Some(DaemonAction::Uninstall) => sm.uninstall(&home),
                     _ => Ok(()),
                 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -19,7 +19,7 @@ fn main() -> anyhow::Result<()> {
         Command::Daemon { action } => match action {
             None => daemon::run(),
             Some(DaemonAction::Status { json }) => daemon::status(json),
-            Some(action @ (DaemonAction::Install | DaemonAction::Uninstall)) => {
+            Some(DaemonAction::Install | DaemonAction::Uninstall) => {
                 use daemon::{InstallOutcome, ServiceManager as _};
 
                 let home = daemon::home_dir()?;
@@ -32,22 +32,24 @@ fn main() -> anyhow::Result<()> {
                 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
                 anyhow::bail!("service management is not supported on this platform");
 
-                if matches!(action, DaemonAction::Install) {
-                    let outcome = sm.install(&home, &socket_path)?;
-                    match outcome {
-                        InstallOutcome::Installed => {
-                            println!("capsule daemon installed and loaded");
+                match action {
+                    Some(DaemonAction::Install) => {
+                        let outcome = sm.install(&home, &socket_path)?;
+                        match outcome {
+                            InstallOutcome::Installed => {
+                                println!("capsule daemon installed and loaded");
+                            }
+                            InstallOutcome::Restarted => {
+                                println!("daemon restarted (binary updated)");
+                            }
+                            InstallOutcome::AlreadyCurrent => {
+                                println!("service is already current, no reload needed");
+                            }
                         }
-                        InstallOutcome::Restarted => {
-                            println!("daemon restarted (binary updated)");
-                        }
-                        InstallOutcome::AlreadyCurrent => {
-                            println!("service is already current, no reload needed");
-                        }
+                        Ok(())
                     }
-                    Ok(())
-                } else {
-                    sm.uninstall(&home)
+                    Some(DaemonAction::Uninstall) => sm.uninstall(&home),
+                    _ => unreachable!(),
                 }
             }
         },

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -19,7 +19,7 @@ fn main() -> anyhow::Result<()> {
         Command::Daemon { action } => match action {
             None => daemon::run(),
             Some(DaemonAction::Status { json }) => daemon::status(json),
-            Some(DaemonAction::Install | DaemonAction::Uninstall) => {
+            Some(action @ (DaemonAction::Install | DaemonAction::Uninstall)) => {
                 use daemon::{InstallOutcome, ServiceManager as _};
 
                 let home = daemon::home_dir()?;
@@ -32,24 +32,22 @@ fn main() -> anyhow::Result<()> {
                 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
                 anyhow::bail!("service management is not supported on this platform");
 
-                match action {
-                    Some(DaemonAction::Install) => {
-                        let outcome = sm.install(&home, &socket_path)?;
-                        match outcome {
-                            InstallOutcome::Installed => {
-                                println!("capsule daemon installed and loaded");
-                            }
-                            InstallOutcome::Restarted => {
-                                println!("daemon restarted (binary updated)");
-                            }
-                            InstallOutcome::AlreadyCurrent => {
-                                println!("service is already current, no reload needed");
-                            }
+                if matches!(action, DaemonAction::Install) {
+                    let outcome = sm.install(&home, &socket_path)?;
+                    match outcome {
+                        InstallOutcome::Installed => {
+                            println!("capsule daemon installed and loaded");
                         }
-                        Ok(())
+                        InstallOutcome::Restarted => {
+                            println!("daemon restarted (binary updated)");
+                        }
+                        InstallOutcome::AlreadyCurrent => {
+                            println!("service is already current, no reload needed");
+                        }
                     }
-                    Some(DaemonAction::Uninstall) => sm.uninstall(&home),
-                    _ => Ok(()),
+                    Ok(())
+                } else {
+                    sm.uninstall(&home)
                 }
             }
         },


### PR DESCRIPTION
## Summary

- Add `InstallOutcome` enum to `ServiceManager::install()` so callers know whether the daemon was freshly installed, restarted due to a binary update, or already up-to-date
- Move user-facing install messages out of the service layer and into the CLI layer (`main.rs`), matching separation-of-concerns principles
- Add `reinstall_service_if_present()` utility that re-runs the full install flow only when a platform service definition (launchd plist / systemd unit) already exists
- Update `restart` in `connect.rs` to call `reinstall_service_if_present()` so that binary updates (e.g. via `brew upgrade`) take effect automatically without requiring a manual `capsule daemon install`

## Test plan

- [ ] `cargo test` — existing install tests updated to assert on `InstallOutcome`; new `test_reinstall_returns_none_without_service` covers the no-service path
- [ ] `task check` passes (fmt, clippy, tests, doc, build all green)
- [ ] Manual: `capsule daemon restart` after `brew upgrade capsule` reloads the updated binary via launchd/systemd without extra steps