### PR TITLE
feat: add slot config for custom module placement

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -118,6 +118,7 @@ cyan = 36
 ```toml
 [[module]]
 name = "rust"
+slot = "line1"              # 省略時 line1; line2 で入力行へ
 when.files = ["Cargo.toml"]
 format = "v{version}"
 icon = "🦀"
@@ -178,3 +179,4 @@ capsule preset              組み込みモジュール定義を TOML として�
 - `crates/prompt-bench`: ベンチマークハーネス
 - `crates/protocol`: wireプロトコルとメッセージコーデック
 - `crates/sys`: プラットフォーム固有の FFI（macOS: launchd、Linux: systemd socketの有効化）
+- `docs/extending.md`: 拡張ガイド（カスタムモジュール、エージェント向け手順）

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ cyan = 36
 ```toml
 [[module]]
 name = "rust"
+slot = "line1"              # default line1; use line2 for the input line
 when.files = ["Cargo.toml"]
 format = "v{version}"
 icon = "🦀"
@@ -181,3 +182,4 @@ capsule preset              Print built-in module definitions as TOML
 - `crates/prompt-bench`: benchmark harness
 - `crates/protocol`: wire protocol and message codec
 - `crates/sys`: platform-specific FFI (launchd on macOS, systemd socket activation on Linux)
+- `docs/extending.md`: extension guide (custom modules, agent workflow)

--- a/crates/cli/src/preset.rs
+++ b/crates/cli/src/preset.rs
@@ -1,5 +1,8 @@
 use capsule_core::{config::ModuleDef, module::preset_module_defs};
 
+const SLOT_HELP: &str =
+    "# slot: \"line1\" (default, after git) | \"line2\" (input line, before time)\n\n";
+
 #[derive(serde::Serialize)]
 #[cfg_attr(test, derive(serde::Deserialize))]
 struct PresetOutput {
@@ -7,17 +10,29 @@ struct PresetOutput {
 }
 
 pub fn run() -> anyhow::Result<()> {
+    print!("{}", render_preset_output()?);
+    Ok(())
+}
+
+fn render_preset_output() -> anyhow::Result<String> {
     let output = PresetOutput {
         module: preset_module_defs(),
     };
     let toml = toml::to_string(&output)?;
-    print!("{toml}");
-    Ok(())
+    Ok(format!("{SLOT_HELP}{toml}"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn preset_output_includes_slot_help() -> anyhow::Result<()> {
+        let rendered = render_preset_output()?;
+        assert!(rendered.starts_with(SLOT_HELP));
+        assert!(rendered.contains("slot = \"line1\""));
+        Ok(())
+    }
 
     #[test]
     fn test_preset_output_round_trips() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -553,6 +553,17 @@ impl<'de> serde::Deserialize<'de> for RegexPattern {
     }
 }
 
+/// Prompt line placement for a custom module.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ModuleSlot {
+    /// Line 1: after git, before command duration (default).
+    #[default]
+    Line1,
+    /// Line 2: before time.
+    Line2,
+}
+
 /// User-defined prompt module entry from `[[module]]` in config.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct ModuleDef {
@@ -578,6 +589,9 @@ pub struct ModuleDef {
     /// Optional arbitration metadata for collapsing competing modules.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub arbitration: Option<Arbitration>,
+    /// Prompt line placement.
+    #[serde(default)]
+    pub slot: ModuleSlot,
 }
 
 fn default_module_format() -> String {

--- a/crates/core/src/config/tests.rs
+++ b/crates/core/src/config/tests.rs
@@ -371,6 +371,67 @@ env = "FOO"
 }
 
 #[test]
+fn module_slot_line2_deserializes() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("config.toml");
+    std::fs::write(
+        &path,
+        r#"
+[[module]]
+name = "node"
+slot = "line2"
+
+[[module.source]]
+env = "NODE_VERSION"
+"#,
+    )?;
+    let config = load_config(&path);
+    assert_eq!(config.module[0].slot, ModuleSlot::Line2);
+    Ok(())
+}
+
+#[test]
+fn module_slot_invalid_rejected() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("config.toml");
+    std::fs::write(
+        &path,
+        r#"
+[[module]]
+name = "test"
+slot = "line3"
+
+[[module.source]]
+env = "FOO"
+"#,
+    )?;
+    assert!(matches!(
+        read_config(&path),
+        Err(ConfigLoadError::Parse { .. })
+    ));
+    Ok(())
+}
+
+#[test]
+fn module_slot_defaults_to_line1() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("config.toml");
+    std::fs::write(
+        &path,
+        r#"
+[[module]]
+name = "test"
+
+[[module.source]]
+env = "FOO"
+"#,
+    )?;
+    let config = load_config(&path);
+    assert_eq!(config.module[0].slot, ModuleSlot::Line1);
+    Ok(())
+}
+
+#[test]
 fn module_multiple_sources() -> Result<(), Box<dyn std::error::Error>> {
     let dir = tempfile::tempdir()?;
     let path = dir.path().join("config.toml");

--- a/crates/core/src/daemon/prompt.rs
+++ b/crates/core/src/daemon/prompt.rs
@@ -1,9 +1,9 @@
 use crate::{
-    config::Config,
+    config::{Config, ModuleSlot},
     module::{
         CmdDurationModule, CustomModuleInfo, DirectoryModule, Module, RenderContext, TimeModule,
     },
-    render::{PromptLines, compose_segments},
+    render::{PromptLines, compose_segments, segment::Segment, style::Style},
 };
 
 /// ASCII Record Separator — delimits key from value in `char_meta` entries.
@@ -96,20 +96,29 @@ pub(super) fn compose_prompt(
         line1.push(config.git.to_segment(git, connector_style));
     }
 
-    for module in &fast.custom_modules {
-        line1.push(module.to_segment(connector_style));
-    }
-    if let Some(custom_modules) = slow.map(|output| &output.custom_modules) {
-        for module in custom_modules {
-            line1.push(module.to_segment(connector_style));
-        }
-    }
+    let slow_custom_modules = slow.map(|output| output.custom_modules.as_slice());
+
+    append_custom_modules(
+        &mut line1,
+        &fast.custom_modules,
+        slow_custom_modules,
+        ModuleSlot::Line1,
+        connector_style,
+    );
 
     if let Some(duration) = &fast.cmd_duration {
         line1.push(config.cmd_duration.to_segment(duration, connector_style));
     }
 
     let mut line2 = Vec::with_capacity(2);
+
+    append_custom_modules(
+        &mut line2,
+        &fast.custom_modules,
+        slow_custom_modules,
+        ModuleSlot::Line2,
+        connector_style,
+    );
 
     if let Some(time) = &fast.time {
         line2.push(config.time.to_segment(time, connector_style));
@@ -135,6 +144,22 @@ pub(super) fn compose_prompt(
     }
 
     result
+}
+
+fn append_custom_modules(
+    line: &mut Vec<Segment>,
+    fast_modules: &[CustomModuleInfo],
+    slow_modules: Option<&[CustomModuleInfo]>,
+    slot: ModuleSlot,
+    connector_style: Style,
+) {
+    for module in fast_modules
+        .iter()
+        .chain(slow_modules.unwrap_or(&[]).iter())
+        .filter(|module| module.slot == slot)
+    {
+        line.push(module.to_segment(connector_style));
+    }
 }
 
 #[cfg(test)]
@@ -183,7 +208,14 @@ mod tests {
             icon: preset.and_then(|def| def.icon.clone()),
             style,
             connector: Some("via".to_owned()),
+            slot: ModuleSlot::default(),
         }
+    }
+
+    fn make_line2_module(name: &str, version: &str) -> CustomModuleInfo {
+        let mut module = make_toolchain_module(name, version);
+        module.slot = ModuleSlot::Line2;
+        module
     }
 
     fn contains_yellow_ansi(line: &str) -> bool {
@@ -279,6 +311,73 @@ mod tests {
         assert!(
             lines.left2.contains("\x1b[31m"),
             "character should be red on error: {}",
+            lines.left2
+        );
+    }
+
+    #[test]
+    fn test_line2_module_on_left2_only() {
+        let mut fast = make_fast_outputs();
+        fast.custom_modules = vec![make_line2_module("node", "v20.0")];
+        let lines = compose_prompt(&fast, None, 80, &default_config());
+        assert!(
+            lines.left2.contains("v20.0"),
+            "line2 module should appear on left2: {}",
+            lines.left2
+        );
+        assert!(
+            !lines.left1.contains("v20.0"),
+            "line2 module should not appear on left1: {}",
+            lines.left1
+        );
+    }
+
+    #[test]
+    fn test_line1_module_not_on_left2() {
+        let fast = make_fast_outputs();
+        let slow = SlowOutput {
+            custom_modules: vec![make_toolchain_module("rust", "v1.82.0")],
+            ..make_slow_output()
+        };
+        let lines = compose_prompt(&fast, Some(&slow), 80, &default_config());
+        assert!(
+            lines.left1.contains("v1.82.0"),
+            "line1 module should appear on left1: {}",
+            lines.left1
+        );
+        assert!(
+            !lines.left2.contains("v1.82.0"),
+            "line1 module should not appear on left2: {}",
+            lines.left2
+        );
+    }
+
+    #[test]
+    fn test_mixed_slots_both_lines() {
+        let mut fast = make_fast_outputs();
+        fast.custom_modules = vec![
+            make_toolchain_module("rust", "v1.82.0"),
+            make_line2_module("node", "v20.0"),
+        ];
+        let lines = compose_prompt(&fast, None, 80, &default_config());
+        assert!(
+            lines.left1.contains("v1.82.0"),
+            "line1 module should appear on left1: {}",
+            lines.left1
+        );
+        assert!(
+            !lines.left1.contains("v20.0"),
+            "line2 module should not appear on left1: {}",
+            lines.left1
+        );
+        assert!(
+            lines.left2.contains("v20.0"),
+            "line2 module should appear on left2: {}",
+            lines.left2
+        );
+        assert!(
+            !lines.left2.contains("v1.82.0"),
+            "line1 module should not appear on left2: {}",
             lines.left2
         );
     }

--- a/crates/core/src/daemon/request/tests.rs
+++ b/crates/core/src/daemon/request/tests.rs
@@ -20,8 +20,8 @@ use super::super::test_support::{
 };
 use crate::{
     config::{
-        CacheConfig, Config, ModuleDef, ModuleWhen, SlowCacheMode, SourceDef, StyleConfig,
-        TimeoutConfig,
+        CacheConfig, Config, ModuleDef, ModuleSlot, ModuleWhen, SlowCacheMode, SourceDef,
+        StyleConfig, TimeoutConfig,
     },
     module::GitStatus,
 };
@@ -579,6 +579,7 @@ async fn test_daemon_env_dep_cache_hit() -> Result<(), Box<dyn std::error::Error
             style: StyleConfig::default(),
             connector: Some("via".to_owned()),
             arbitration: None,
+            slot: ModuleSlot::default(),
         }],
         ..Config::default()
     };
@@ -674,6 +675,7 @@ async fn test_fast_env_module_no_blocking_pool() -> Result<(), Box<dyn std::erro
             style: StyleConfig::default(),
             connector: None,
             arbitration: None,
+            slot: ModuleSlot::default(),
         }],
         timeout: TimeoutConfig {
             fast_ms: 0,
@@ -1081,6 +1083,7 @@ async fn test_daemon_env_dep_prevents_cache_reuse() -> Result<(), Box<dyn std::e
             style: StyleConfig::default(),
             connector: Some("via".to_owned()),
             arbitration: None,
+            slot: ModuleSlot::default(),
         }],
         ..Config::default()
     };

--- a/crates/core/src/daemon/test_support.rs
+++ b/crates/core/src/daemon/test_support.rs
@@ -17,7 +17,7 @@ use super::{
     listener::{self, ListenerMode},
 };
 use crate::{
-    config::{Config, ModuleDef, ModuleWhen, SourceDef, StyleConfig},
+    config::{Config, ModuleDef, ModuleSlot, ModuleWhen, SourceDef, StyleConfig},
     module::{GitError, GitProvider, GitStatus},
     sealed,
 };
@@ -86,6 +86,7 @@ pub(super) fn make_sleep_module(name: &str, sleep_ms: u32, output: &str) -> Modu
         style: StyleConfig::default(),
         connector: Some("via".to_owned()),
         arbitration: None,
+        slot: ModuleSlot::default(),
     }
 }
 

--- a/crates/core/src/module/custom.rs
+++ b/crates/core/src/module/custom.rs
@@ -20,7 +20,7 @@ use regex_lite::Regex;
 
 use super::ModuleSpeed;
 use crate::{
-    config::{Arbitration, ModuleWhen},
+    config::{Arbitration, ModuleSlot, ModuleWhen},
     render::{
         segment::{Connector, Icon, Segment},
         style::Style,
@@ -48,6 +48,8 @@ pub struct ResolvedModule {
     pub speed: ModuleSpeed,
     /// Optional arbitration rule for collapsing competing detected modules.
     pub arbitration: Option<Arbitration>,
+    /// Prompt line placement.
+    pub slot: ModuleSlot,
 }
 
 impl ResolvedModule {
@@ -99,6 +101,8 @@ pub struct CustomModuleInfo {
     pub style: Style,
     /// Connector word.
     pub connector: Option<String>,
+    /// Prompt line placement.
+    pub slot: ModuleSlot,
 }
 
 impl CustomModuleInfo {

--- a/crates/core/src/module/custom/builtins.rs
+++ b/crates/core/src/module/custom/builtins.rs
@@ -1,5 +1,7 @@
 use crate::{
-    config::{Arbitration, ModuleDef, ModuleWhen, RegexPattern, SourceDef, StyleConfig},
+    config::{
+        Arbitration, ModuleDef, ModuleSlot, ModuleWhen, RegexPattern, SourceDef, StyleConfig,
+    },
     render::style::Color,
 };
 
@@ -29,6 +31,7 @@ pub fn preset_module_defs() -> Vec<ModuleDef> {
             style: StyleConfig::fg(Color::Red),
             connector: Some("via".to_owned()),
             arbitration: None,
+            slot: ModuleSlot::default(),
         },
         ModuleDef {
             name: "bun".to_owned(),
@@ -64,6 +67,7 @@ pub fn preset_module_defs() -> Vec<ModuleDef> {
                 group: JS_RUNTIME_ARBITRATION_GROUP.to_owned(),
                 priority: BUN_ARBITRATION_PRIORITY,
             }),
+            slot: ModuleSlot::default(),
         },
         ModuleDef {
             name: "node".to_owned(),
@@ -95,6 +99,7 @@ pub fn preset_module_defs() -> Vec<ModuleDef> {
                 group: JS_RUNTIME_ARBITRATION_GROUP.to_owned(),
                 priority: NODE_ARBITRATION_PRIORITY,
             }),
+            slot: ModuleSlot::default(),
         },
         ModuleDef {
             name: "go".to_owned(),
@@ -114,6 +119,7 @@ pub fn preset_module_defs() -> Vec<ModuleDef> {
             style: StyleConfig::fg(Color::Cyan),
             connector: Some("via".to_owned()),
             arbitration: None,
+            slot: ModuleSlot::default(),
         },
         ModuleDef {
             name: "python".to_owned(),
@@ -133,6 +139,7 @@ pub fn preset_module_defs() -> Vec<ModuleDef> {
             style: StyleConfig::fg(Color::Yellow),
             connector: Some("via".to_owned()),
             arbitration: None,
+            slot: ModuleSlot::default(),
         },
         ModuleDef {
             name: "ruby".to_owned(),
@@ -154,6 +161,7 @@ pub fn preset_module_defs() -> Vec<ModuleDef> {
             style: StyleConfig::fg(Color::Red),
             connector: Some("via".to_owned()),
             arbitration: None,
+            slot: ModuleSlot::default(),
         },
     ]
 }

--- a/crates/core/src/module/custom/compile.rs
+++ b/crates/core/src/module/custom/compile.rs
@@ -40,6 +40,7 @@ fn compile_module_def(def: ModuleDef) -> ResolvedModule {
         connector: def.connector,
         speed,
         arbitration: def.arbitration,
+        slot: def.slot,
     }
 }
 

--- a/crates/core/src/module/custom/detect.rs
+++ b/crates/core/src/module/custom/detect.rs
@@ -209,6 +209,7 @@ pub(super) fn format_module(
         icon: def.icon.clone(),
         style: def.style,
         connector: def.connector.clone(),
+        slot: def.slot,
     })
 }
 

--- a/crates/core/src/module/custom/facts.rs
+++ b/crates/core/src/module/custom/facts.rs
@@ -371,6 +371,7 @@ mod tests {
             connector: None,
             speed: ModuleSpeed::Fast,
             arbitration,
+            slot: crate::config::ModuleSlot::default(),
         }
     }
 
@@ -381,6 +382,7 @@ mod tests {
             icon: None,
             style: Style::default(),
             connector: None,
+            slot: crate::config::ModuleSlot::default(),
         }
     }
 

--- a/crates/core/src/module/custom/tests.rs
+++ b/crates/core/src/module/custom/tests.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use super::*;
 use crate::{
-    config::{ModuleDef, RegexPattern, SourceDef, StyleConfig},
+    config::{ModuleDef, ModuleSlot, RegexPattern, SourceDef, StyleConfig},
     render::style::Color,
 };
 
@@ -41,6 +41,7 @@ fn resolve_modules_single() {
         style: StyleConfig::fg(Color::Yellow),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }];
     let resolved = resolve_modules(&user);
     assert_eq!(resolved.len(), 1);
@@ -69,6 +70,7 @@ fn resolve_modules_with_command() {
         style: StyleConfig::fg(Color::Yellow),
         connector: Some("via".to_owned()),
         arbitration: None,
+        slot: ModuleSlot::default(),
     }];
     let resolved = resolve_modules(&user);
     assert_eq!(resolved.len(), 1);
@@ -101,6 +103,7 @@ fn resolve_modules_keeps_arbitration() {
         style: StyleConfig::default(),
         connector: None,
         arbitration: Some(arbitration("javascript", 30)),
+        slot: ModuleSlot::default(),
     }];
 
     let resolved = resolve_modules(&user);
@@ -128,6 +131,7 @@ fn resolve_modules_fast_env() {
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }];
     let resolved = resolve_modules(&user);
     let m = resolved.iter().find(|r| r.name == "env_only");
@@ -160,6 +164,7 @@ fn resolve_modules_slow_command() {
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }];
     let resolved = resolve_modules(&user);
     let m = resolved.iter().find(|r| r.name == "mixed");
@@ -183,6 +188,7 @@ fn resolve_modules_filters_empty_command() {
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
 
     let m = defs.iter().find(|r| r.name == "empty_cmd");
@@ -214,6 +220,7 @@ async fn detect_env_source() {
         style: StyleConfig::fg(Color::Yellow),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
 
     let env_vars = vec![("AWS_PROFILE".to_owned(), "production".to_owned())];
@@ -245,6 +252,7 @@ async fn detect_env_source_missing() {
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
 
     let results = detect_modules(&defs, Path::new("/tmp"), &[], None, ModuleSpeed::Fast).await;
@@ -278,6 +286,7 @@ async fn detect_file_source() -> Result<(), Box<dyn std::error::Error>> {
         style: StyleConfig::default(),
         connector: Some("via".to_owned()),
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
 
     let results = detect_modules(&defs, dir.path(), &[], None, ModuleSpeed::Fast).await;
@@ -310,6 +319,7 @@ async fn detect_command_source() -> Result<(), Box<dyn std::error::Error>> {
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
 
     let results = detect_modules(&defs, dir.path(), &[], None, ModuleSpeed::Slow).await;
@@ -351,6 +361,7 @@ async fn detect_fast_source_preferred() -> Result<(), Box<dyn std::error::Error>
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
 
     let env_vars = vec![("MY_VERSION".to_owned(), "from-env".to_owned())];
@@ -385,6 +396,7 @@ async fn detect_format_string() {
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
 
     let env_vars = vec![("FOO".to_owned(), "1.0".to_owned())];
@@ -414,6 +426,7 @@ async fn detect_env_regex() {
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
 
     let env_vars = vec![("VERSION_STR".to_owned(), "v1.23.456-beta".to_owned())];
@@ -445,6 +458,7 @@ async fn detect_when_missing_files() -> Result<(), Box<dyn std::error::Error>> {
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
 
     let env_vars = vec![("FOO".to_owned(), "bar".to_owned())];
@@ -473,6 +487,7 @@ async fn detect_when_empty() {
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
 
     let env_vars = vec![("FOO".to_owned(), "bar".to_owned())];
@@ -504,6 +519,7 @@ async fn detect_command_failure() -> Result<(), Box<dyn std::error::Error>> {
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
 
     let results = detect_modules(&defs, dir.path(), &[], None, ModuleSpeed::Slow).await;
@@ -532,6 +548,7 @@ async fn detect_same_group_keeps_lower_priority() {
             style: StyleConfig::default(),
             connector: None,
             arbitration: Some(arbitration("runtime", 20)),
+            slot: ModuleSlot::default(),
         },
         ModuleDef {
             name: "beta".to_owned(),
@@ -548,6 +565,7 @@ async fn detect_same_group_keeps_lower_priority() {
             style: StyleConfig::default(),
             connector: None,
             arbitration: Some(arbitration("runtime", 10)),
+            slot: ModuleSlot::default(),
         },
     ]);
 
@@ -584,6 +602,7 @@ async fn detect_same_group_keeps_earlier_definition() {
             style: StyleConfig::default(),
             connector: None,
             arbitration: Some(arbitration("runtime", 10)),
+            slot: ModuleSlot::default(),
         },
         ModuleDef {
             name: "second".to_owned(),
@@ -600,6 +619,7 @@ async fn detect_same_group_keeps_earlier_definition() {
             style: StyleConfig::default(),
             connector: None,
             arbitration: Some(arbitration("runtime", 10)),
+            slot: ModuleSlot::default(),
         },
     ]);
 
@@ -636,6 +656,7 @@ async fn detect_without_arbitration() {
             style: StyleConfig::default(),
             connector: None,
             arbitration: Some(arbitration("runtime", 10)),
+            slot: ModuleSlot::default(),
         },
         ModuleDef {
             name: "plain".to_owned(),
@@ -652,6 +673,7 @@ async fn detect_without_arbitration() {
             style: StyleConfig::default(),
             connector: None,
             arbitration: None,
+            slot: ModuleSlot::default(),
         },
     ]);
 
@@ -693,6 +715,7 @@ fn request_facts_matching_inputs() -> Result<(), Box<dyn std::error::Error>> {
             style: StyleConfig::default(),
             connector: None,
             arbitration: None,
+            slot: ModuleSlot::default(),
         },
         ModuleDef {
             name: "terraform".to_owned(),
@@ -721,6 +744,7 @@ fn request_facts_matching_inputs() -> Result<(), Box<dyn std::error::Error>> {
             style: StyleConfig::default(),
             connector: None,
             arbitration: None,
+            slot: ModuleSlot::default(),
         },
     ]);
 
@@ -756,6 +780,7 @@ async fn request_facts_uses_forwarded_path() -> Result<(), Box<dyn std::error::E
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
     let module = defs.iter().find(|resolved| resolved.name == "tool");
     let Some(module) = module else {
@@ -814,6 +839,7 @@ async fn detect_ignores_forwarded_path_env() -> Result<(), Box<dyn std::error::E
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
 
     let bin_dir = tempfile::tempdir()?;
@@ -866,6 +892,7 @@ async fn detect_empty_env_value() {
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
 
     let env_vars = vec![("EMPTY_VAR".to_owned(), String::new())];
@@ -903,6 +930,7 @@ async fn detect_empty_file_filtered() -> Result<(), Box<dyn std::error::Error>> 
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
 
     let results = detect_modules(&defs, dir.path(), &[], None, ModuleSpeed::Fast).await;
@@ -939,6 +967,7 @@ async fn detect_file_traversal_rejected() -> Result<(), Box<dyn std::error::Erro
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
 
     let results = detect_modules(&defs, &sub, &[], None, ModuleSpeed::Fast).await;
@@ -966,6 +995,7 @@ async fn detect_format_no_recursive_expansion() {
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
 
     let env_vars = vec![("INJECT_VAR".to_owned(), "{value}".to_owned())];
@@ -1006,6 +1036,7 @@ async fn detect_command_no_shell_injection() -> Result<(), Box<dyn std::error::E
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
 
     let _results = detect_modules(&defs, dir.path(), &[], None, ModuleSpeed::Slow).await;
@@ -1056,6 +1087,7 @@ async fn detect_uses_declared_command_source_order() -> Result<(), Box<dyn std::
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
     let module = defs.iter().find(|resolved| resolved.name == "runtime");
     let Some(module) = module else {
@@ -1097,6 +1129,7 @@ async fn detect_resolves_fast_file_source() -> Result<(), Box<dyn std::error::Er
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
     let module = defs.iter().find(|resolved| resolved.name == "runtime");
     let Some(module) = module else {
@@ -1137,6 +1170,7 @@ async fn detect_concurrent_no_corruption() -> Result<(), Box<dyn std::error::Err
         style: StyleConfig::default(),
         connector: None,
         arbitration: None,
+        slot: ModuleSlot::default(),
     }]);
 
     let defs = std::sync::Arc::new(defs);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -184,6 +184,35 @@ Line 2 (input):  at [time] [character]
 | Cache | LRU (1024 entries, key = cwd + config_generation + dep_hash) | slow module 結果の再利用。dep_hash が env/file 依存を反映するため TTL 不要 |
 | Slow coalescing | watch channel per cache key | 同一 cwd への concurrent request で重複 spawn を防止 |
 
+## Intentionally Not in Core
+
+| Capability | Why not core | Extension path |
+|---|---|---|
+| Toolchain display | Per-language variance | `[[module]]` / `capsule preset` |
+| 3+ line layouts | v1 Starship-compatible 2 lines | `slot = "line2"` only; line-1 order fixed |
+| glob `when.files` | perf / escaping | exact filename match |
+| truecolor / style DSL | out of Theme 25 scope | `[color_map]` + `StyleConfig` |
+| Third-party Rust modules | sealed trait policy | config DSL (`[[module]]`) |
+| Linux / non-zsh shells | target platform scope | best-effort fallback |
+| org-wide config registry | single user config path | shared preset TOML + manual paste |
+
+Additional v1 non-goals live in [TODO.md](../TODO.md) (Open Questions).
+
+## Request Pipeline Stages
+
+Named stages in `crates/core/src/daemon/request/pipeline.rs` and `handle_request`:
+
+| Stage | Role | Extension today |
+|---|---|---|
+| `ConfigSnapshot` | User config hot-reload (mtime) | — |
+| `GatedPromptRequest` | Stale generation discard | — |
+| `CollectedFacts` | cwd env/file facts, cache key | — |
+| Fast detect | env/file `[[module]]` | module `slot` at compose |
+| Slow detect | command sources + git | same |
+| `compose_prompt` | 2-line layout | `line1` / `line2` slots |
+
+See [extending.md](extending.md) for agent workflow.
+
 ## Revisit Trigger
 
 - multi-user / multi-session を同一 daemon で扱う必要 -> runtime を multi-thread に変更

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,0 +1,39 @@
+# Extending capsule
+
+Read this file when adding prompt segments, team presets, or automating config changes (including AI agents).
+
+## Extension surfaces
+
+| Surface | Use for |
+|---------|---------|
+| `[[module]]` in config | Custom prompt segments (env / file / command sources) |
+| `capsule preset` | Bootstrap toolchain module TOML |
+| `[character]`, `[git]`, … | Built-in module styling only |
+
+Rust `Module` implementations are **not** a public extension point (`sealed` trait). Extend via config DSL.
+
+## Self-modification loop (agents)
+
+1. **Bootstrap toolchains:** `capsule preset` and paste into user config.
+2. **Verify:** `task test` and open a shell in the target directory to inspect the prompt.
+3. **Env-dependent modules:** after adding new `env` sources, **reconnect** the coproc (`exec zsh` or new terminal). HelloAck publishes required env var names only at connect time.
+
+Hot-reload picks up TOML edits on the next prompt without restarting the daemon.
+
+## Module slots
+
+```toml
+[[module]]
+name = "k8s"
+slot = "line2"   # default: "line1"
+```
+
+- `line1` — after git, before command duration (default).
+- `line2` — before time on the input line.
+
+Line-1 segment order among built-ins is fixed; see [architecture.md](architecture.md).
+
+## Further reading
+
+- [architecture.md](architecture.md) — negative space, request pipeline stages
+- [README.ja.md](../README.ja.md) — user-facing config examples


### PR DESCRIPTION
## Summary

- Add `ModuleSlot` enum (`Line1` / `Line2`) to config, allowing custom modules to be placed on either prompt line
- Default is `Line1` (after git, before command duration); `Line2` places modules before time on the input line
- Add `docs/extending.md` documenting extension surfaces, the agent self-modification loop, and `slot` usage
- Update `docs/architecture.md` with "Intentionally Not in Core" table and request pipeline stages
- `capsule preset` output now includes slot usage hints

## Why

Custom modules on line 1 push the prompt past terminal width in narrow terminals or when many toolchains are active. `slot = "line2"` gives an escape hatch without a full layout rework. The new `docs/extending.md` also serves as the canonical reference for agent-driven config automation.

## Testing

- Unit tests for slot deserialization, default values, and invalid value rejection
- Unit tests for slot-based prompt line assignment (line2-only, line1-not-on-line2, mixed slots)
- `task check` passes: fmt, clippy, all 426 tests, docs, build
