### PR TITLE
feat: secure release pipeline with verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
+      attestations: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -29,6 +31,8 @@ jobs:
             os_name: linux
             arch: arm64
             cross: true
+    env:
+      ARCHIVE_NAME: capsule-${{ github.ref_name }}-${{ matrix.os_name }}-${{ matrix.arch }}.tar.gz
 
     steps:
       - name: Checkout code
@@ -54,17 +58,24 @@ jobs:
           TARGET: ${{ matrix.target }}
 
       - name: Create archive
-        run: tar -czf "capsule-${GITHUB_REF_NAME}-${OS_NAME}-${ARCH}.tar.gz" -C "target/${TARGET}/release" capsule
+        run: |
+          tar -czf "$ARCHIVE_NAME" -C "target/${TARGET}/release" capsule
+          shasum -a 256 "$ARCHIVE_NAME" > "$ARCHIVE_NAME.sha256"
         env:
           TARGET: ${{ matrix.target }}
-          OS_NAME: ${{ matrix.os_name }}
-          ARCH: ${{ matrix.arch }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+        with:
+          subject-path: ${{ env.ARCHIVE_NAME }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: capsule-${{ matrix.os_name }}-${{ matrix.arch }}
-          path: capsule-${{ github.ref_name }}-${{ matrix.os_name }}-${{ matrix.arch }}.tar.gz
+          path: |
+            ${{ env.ARCHIVE_NAME }}
+            ${{ env.ARCHIVE_NAME }}.sha256
 
   release:
     name: Release
@@ -94,15 +105,43 @@ jobs:
             touch /tmp/release-notes.md
           fi
 
-      - name: Create GitHub Release
+      - name: Verify assets and upsert GitHub Release
         run: |
-          gh release create "$TAG_NAME" \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "$TAG_NAME" \
-            --notes-file /tmp/release-notes.md \
-            "artifacts/capsule-darwin-arm64/capsule-${TAG_NAME}-darwin-arm64.tar.gz" \
-            "artifacts/capsule-linux-amd64/capsule-${TAG_NAME}-linux-amd64.tar.gz" \
+          set -euo pipefail
+
+          archives=(
+            "artifacts/capsule-darwin-arm64/capsule-${TAG_NAME}-darwin-arm64.tar.gz"
+            "artifacts/capsule-linux-amd64/capsule-${TAG_NAME}-linux-amd64.tar.gz"
             "artifacts/capsule-linux-arm64/capsule-${TAG_NAME}-linux-arm64.tar.gz"
+          )
+          assets=()
+
+          for archive in "${archives[@]}"; do
+            checksum="$archive.sha256"
+            test -f "$archive"
+            test -f "$checksum"
+            (cd "$(dirname "$archive")" && shasum -a 256 --check "$(basename "$checksum")")
+            assets+=("$archive" "$checksum")
+          done
+
+          if gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release edit "$TAG_NAME" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$TAG_NAME" \
+              --notes-file /tmp/release-notes.md \
+              --verify-tag
+          else
+            gh release create "$TAG_NAME" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$TAG_NAME" \
+              --notes-file /tmp/release-notes.md \
+              --verify-tag
+          fi
+
+          gh release upload "$TAG_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber \
+            "${assets[@]}"
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,9 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
+      # Required by actions/attest to persist artifact attestations.
       attestations: write
+      # Required by actions/attest to request a Sigstore OIDC certificate.
       id-token: write
     strategy:
       fail-fast: false
@@ -124,24 +126,64 @@ jobs:
             assets+=("$archive" "$checksum")
           done
 
-          if gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release edit "$TAG_NAME" \
+          if release_is_draft="$(
+            gh release view "$TAG_NAME" \
               --repo "$GITHUB_REPOSITORY" \
-              --title "$TAG_NAME" \
-              --notes-file /tmp/release-notes.md \
-              --verify-tag
+              --json isDraft \
+              --jq '.isDraft' \
+              2>/dev/null
+          )"; then
+            if [[ "$release_is_draft" == "true" ]]; then
+              gh release upload "$TAG_NAME" \
+                --repo "$GITHUB_REPOSITORY" \
+                --clobber \
+                "${assets[@]}"
+
+              gh release edit "$TAG_NAME" \
+                --repo "$GITHUB_REPOSITORY" \
+                --title "$TAG_NAME" \
+                --notes-file /tmp/release-notes.md \
+                --verify-tag \
+                --draft=false
+            else
+              missing_assets=()
+              mapfile -t existing_assets < <(
+                gh release view "$TAG_NAME" \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --json assets \
+                  --jq '.assets[].name'
+              )
+
+              for asset in "${assets[@]}"; do
+                asset_name="$(basename "$asset")"
+                asset_exists=false
+                for existing_asset in "${existing_assets[@]}"; do
+                  if [[ "$existing_asset" == "$asset_name" ]]; then
+                    asset_exists=true
+                    break
+                  fi
+                done
+
+                if [[ "$asset_exists" == "false" ]]; then
+                  missing_assets+=("$asset_name")
+                fi
+              done
+
+              if ((${#missing_assets[@]} > 0)); then
+                printf 'published release %s is missing immutable assets:\n' "$TAG_NAME" >&2
+                printf '  %s\n' "${missing_assets[@]}" >&2
+                echo "cannot repair published release assets without mutating the release" >&2
+                exit 1
+              fi
+            fi
           else
             gh release create "$TAG_NAME" \
+              "${assets[@]}" \
               --repo "$GITHUB_REPOSITORY" \
               --title "$TAG_NAME" \
               --notes-file /tmp/release-notes.md \
               --verify-tag
           fi
-
-          gh release upload "$TAG_NAME" \
-            --repo "$GITHUB_REPOSITORY" \
-            --clobber \
-            "${assets[@]}"
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ github.ref_name }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -8,14 +8,52 @@ on:
       - completed
   workflow_dispatch:
 
+env:
+  RELEASE_CHECKOUT_REF: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.event.workflow_run.head_sha }}
+
 jobs:
+  should-run:
+    name: Should run
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - name: Check release gate
+        id: check
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$CONCLUSION" != "success" || "$WORKFLOW_EVENT" != "push" || "$HEAD_BRANCH" != "main" ]]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          latest_main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
+          if [[ "$HEAD_SHA" == "$latest_main_sha" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion || '' }}
+          WORKFLOW_EVENT: ${{ github.event.workflow_run.event || '' }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch || '' }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha || '' }}
+
   release:
     name: Release
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == 'main')
+    needs: should-run
+    if: needs.should-run.outputs.run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
@@ -37,7 +75,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha || 'main' }}
+          ref: ${{ env.RELEASE_CHECKOUT_REF }}
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token }}
 
@@ -50,11 +88,8 @@ jobs:
 
   release-pr:
     name: Release PR
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == 'main')
+    needs: should-run
+    if: needs.should-run.outputs.run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
@@ -78,7 +113,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha || 'main' }}
+          ref: ${{ env.RELEASE_CHECKOUT_REF }}
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,13 +1,21 @@
 name: Tag
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+  workflow_dispatch:
 
 jobs:
   release:
     name: Release
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
@@ -29,6 +37,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha || 'main' }}
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token }}
 
@@ -41,6 +50,11 @@ jobs:
 
   release-pr:
     name: Release PR
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
@@ -64,6 +78,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha || 'main' }}
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token }}
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,8 +1,11 @@
 [workspace]
+release = false
 publish = false
 git_release_enable = false
+git_only = true
 release_always = false
 
 [[package]]
 name = "capsule-cli"
+release = true
 git_tag_name = "v{{ version }}"


### PR DESCRIPTION
## Summary

- Replace `push`-on-main trigger in `tag.yml` with `workflow_run` on CI completion, so releases only run after CI passes on main
- Add SHA256 checksum generation for release archives and verify before upload
- Add artifact attestations via `actions/attest` for supply chain security
- Switch release creation to upsert logic (create or edit) for idempotency
- Move release-plz tag-only mode: `git_only = true`, release scope scoped to `capsule-cli` only

## Why

The old pipeline would attempt releases immediately on push to main, without waiting for CI. If CI failed, the release would still be created with potentially broken artifacts. The new pipeline gates on CI success, adds integrity verification (checksums + attestations), and is safe to rerun on the same tag.

## Testing

- CI and all tests pass on this branch
- Release workflow changes follow the same patterns used in the repository
