### PR TITLE
feat: add Nix flake with declarative daemon support

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,36 @@
+name: Nix
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  nix:
+    name: Nix (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Nix
+        uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd # v31.9.1
+
+      - name: Set up Task
+        uses: shuymn/github-actions/.github/actions/setup-task@e3d3485d66cf3fe598d8954fff89e81c5cac57e0
+
+      - name: Check Nix flake
+        run: task nix:check

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   nix:
     name: Nix (${{ matrix.os }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
 
   release:
     name: Release
-    needs: [build, nix-cache]
+    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
   nix-cache:
     name: Nix cache (${{ matrix.os }})
     needs: build
+    continue-on-error: true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     permissions:
@@ -101,7 +102,7 @@ jobs:
 
   release:
     name: Release
-    needs: build
+    needs: nix-cache
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,9 +66,42 @@ jobs:
           name: capsule-${{ matrix.os_name }}-${{ matrix.arch }}
           path: capsule-${{ github.ref_name }}-${{ matrix.os_name }}-${{ matrix.arch }}.tar.gz
 
+  nix-cache:
+    name: Nix cache (${{ matrix.os }})
+    needs: build
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Nix
+        uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd # v31.9.1
+
+      - name: Set up Cachix
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: shuymn
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          skipPush: true
+
+      - name: Push Nix package outputs to Cachix
+        run: |
+          paths="$(nix build --no-link --no-update-lock-file --print-build-logs --print-out-paths .#default .#capsule)"
+          printf '%s\n' "$paths" | sort -u | xargs cachix push shuymn
+
   release:
     name: Release
-    needs: build
+    needs: [build, nix-cache]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
 
   release:
     name: Release
-    needs: nix-cache
+    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/README.ja.md
+++ b/README.ja.md
@@ -25,6 +25,8 @@ at <time> ❯
 
 要件: macOS または Linux、`zsh`。
 
+### Homebrew
+
 ```bash
 # 1. バイナリのインストール
 brew install shuymn/tap/capsule
@@ -35,6 +37,69 @@ capsule daemon install   # macOS: launchd  |  Linux: systemd --user
 # 3. .zshrc へ追記
 eval "$(capsule init zsh)"
 ```
+
+### Nix
+
+インストールせずに実行する場合:
+
+```bash
+nix run github:shuymn/capsule -- --version
+```
+
+バイナリのみをインストールする場合:
+
+```bash
+nix profile install github:shuymn/capsule
+```
+
+daemon を宣言的に管理する場合は、flake input に capsule を追加し、対応する module を import して `programs.capsule.daemon` を有効にします:
+
+```nix
+inputs.capsule.url = "github:shuymn/capsule";
+```
+
+```nix
+# Home Manager
+{
+  imports = [ inputs.capsule.homeManagerModules.default ];
+
+  programs.capsule = {
+    enable = true;
+    daemon.enable = true;
+  };
+
+  programs.zsh.initContent = ''
+    eval "$(capsule init zsh)"
+  '';
+}
+```
+
+```nix
+# NixOS
+{
+  imports = [ inputs.capsule.nixosModules.default ];
+
+  programs.capsule = {
+    enable = true;
+    daemon.enable = true;
+  };
+}
+```
+
+```nix
+# nix-darwin
+{
+  imports = [ inputs.capsule.darwinModules.default ];
+
+  system.primaryUser = "alice";
+  programs.capsule = {
+    enable = true;
+    daemon.enable = true;
+  };
+}
+```
+
+Nix module を使う場合は `capsule daemon install` を実行しないでください。launchd/systemd の定義は module が管理します。以前に命令型で daemon をインストールしていた場合は、module を有効にする前に一度 `capsule daemon uninstall` を実行してください。
 
 toolchainモジュールを用意するには、`capsule preset` を実行してその出力を設定ファイルに貼り付けます。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -58,6 +58,8 @@ daemon を宣言的に管理する場合は、flake input に capsule を追加�
 inputs.capsule.url = "github:shuymn/capsule";
 ```
 
+以下の module 断片は、すでに `home.stateVersion` または `system.stateVersion` を設定済みの既存の Home Manager / NixOS / nix-darwin 設定にマージする前提です。
+
 ```nix
 # Home Manager
 {

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ For declarative daemon management, add capsule to your flake inputs, import the 
 inputs.capsule.url = "github:shuymn/capsule";
 ```
 
+The module snippets below are meant to be merged into an existing Home Manager, NixOS, or nix-darwin configuration that already sets `home.stateVersion` or `system.stateVersion`.
+
 ```nix
 # Home Manager
 {

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Line 1 truncates the directory first and drops trailing segments when it would o
 
 Requirements: macOS or Linux, `zsh`.
 
+### Homebrew
+
 ```bash
 # 1. Install the binary
 brew install shuymn/tap/capsule
@@ -37,6 +39,69 @@ capsule daemon install   # macOS: launchd  |  Linux: systemd --user
 # 3. Add to .zshrc
 eval "$(capsule init zsh)"
 ```
+
+### Nix
+
+Run without installing:
+
+```bash
+nix run github:shuymn/capsule -- --version
+```
+
+Install only the binary:
+
+```bash
+nix profile install github:shuymn/capsule
+```
+
+For declarative daemon management, add capsule to your flake inputs, import the matching module, and enable `programs.capsule.daemon`:
+
+```nix
+inputs.capsule.url = "github:shuymn/capsule";
+```
+
+```nix
+# Home Manager
+{
+  imports = [ inputs.capsule.homeManagerModules.default ];
+
+  programs.capsule = {
+    enable = true;
+    daemon.enable = true;
+  };
+
+  programs.zsh.initContent = ''
+    eval "$(capsule init zsh)"
+  '';
+}
+```
+
+```nix
+# NixOS
+{
+  imports = [ inputs.capsule.nixosModules.default ];
+
+  programs.capsule = {
+    enable = true;
+    daemon.enable = true;
+  };
+}
+```
+
+```nix
+# nix-darwin
+{
+  imports = [ inputs.capsule.darwinModules.default ];
+
+  system.primaryUser = "alice";
+  programs.capsule = {
+    enable = true;
+    daemon.enable = true;
+  };
+}
+```
+
+When using a Nix module, do not run `capsule daemon install`; the module owns the launchd/systemd definition. If you previously installed the daemon imperatively, run `capsule daemon uninstall` once before enabling the module.
 
 To bootstrap toolchain modules, run `capsule preset` and paste the output into your config file.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -31,6 +31,17 @@ tasks:
     cmds:
       - cargo run -p capsule-cli
 
+  nix:check:
+    desc: Check Nix flake outputs
+    summary: |
+      Checks flake evaluation, public package builds, and app entrypoints without updating flake.lock.
+    cmds:
+      - nix flake check --all-systems --no-build --no-update-lock-file
+      - nix flake check --no-update-lock-file --print-build-logs
+      - nix build --no-link --no-update-lock-file --print-build-logs .#default .#capsule
+      - nix run --no-update-lock-file .# -- --version
+      - nix run --no-update-lock-file .#capsule -- --version
+
   test:
     desc: Run all tests
     summary: |

--- a/crates/cli/src/connect.rs
+++ b/crates/cli/src/connect.rs
@@ -349,10 +349,10 @@ async fn relay(socket_path: &Path, session_id: SessionId) -> anyhow::Result<()> 
                     retries = 0;
                     break s;
                 }
-                Err(e) if retries >= MAX_RETRIES => return Err(e.into()),
+                Err(e) if retries >= MAX_RETRIES => return Err(reconnect_exhausted_error(e)),
                 Err(_) => {
                     retries += 1;
-                    reconnect_daemon(socket_path).await?;
+                    reconnect_daemon(socket_path).await;
                 }
             }
         };
@@ -382,7 +382,7 @@ async fn relay(socket_path: &Path, session_id: SessionId) -> anyhow::Result<()> 
         if retries >= MAX_RETRIES {
             return Ok(());
         }
-        reconnect_daemon(socket_path).await?;
+        reconnect_daemon(socket_path).await;
     }
 }
 
@@ -615,25 +615,53 @@ fn parse_env_meta(meta: &[u8]) -> Vec<(String, String)> {
     vars
 }
 
-fn bail_if_nix_managed_daemon(home: &Path, action: &str) -> anyhow::Result<()> {
-    if let Some(definition) = crate::daemon::nix_managed_service_definition(home) {
-        anyhow::bail!(
+fn nix_managed_daemon_message(home: &Path, action: &str) -> Option<String> {
+    crate::daemon::nix_managed_service_definition(home).map(|definition| {
+        format!(
             "capsule daemon is managed by Nix at {}; activate or restart the Nix-managed service/socket instead of {action}",
             definition.display()
-        );
+        )
+    })
+}
+
+fn bail_if_nix_managed_daemon(home: &Path, action: &str) -> anyhow::Result<()> {
+    if let Some(message) = nix_managed_daemon_message(home, action) {
+        anyhow::bail!("{message}");
     }
     Ok(())
 }
 
+fn reconnect_exhausted_error(error: std::io::Error) -> anyhow::Error {
+    let home = crate::daemon::home_dir().ok();
+    reconnect_exhausted_error_with_home(error, home.as_deref())
+}
+
+fn reconnect_exhausted_error_with_home(
+    error: std::io::Error,
+    home: Option<&Path>,
+) -> anyhow::Error {
+    if let Some(home) = home
+        && let Some(message) =
+            nix_managed_daemon_message(home, "waiting for automatic reconnection")
+    {
+        return anyhow::anyhow!("{message}; last connect error: {error}");
+    }
+    error.into()
+}
+
 /// Wait briefly, then ensure the daemon is running for reconnection.
-async fn reconnect_daemon(socket_path: &Path) -> anyhow::Result<()> {
+async fn reconnect_daemon(socket_path: &Path) {
+    let home = crate::daemon::home_dir().ok();
+    reconnect_daemon_with_home(socket_path, home.as_deref()).await;
+}
+
+async fn reconnect_daemon_with_home(socket_path: &Path, home: Option<&Path>) {
     tokio::time::sleep(RETRY_INTERVAL).await;
-    if let Ok(home) = crate::daemon::home_dir() {
-        bail_if_nix_managed_daemon(&home, "starting a standalone daemon")?;
+    if home.is_some_and(|home| crate::daemon::nix_managed_service_definition(home).is_some()) {
+        return;
     }
     let path = socket_path.to_owned();
     let _ = tokio::task::spawn_blocking(move || ensure_daemon(&path)).await;
-    Ok(())
 }
 
 /// Returns `true` if the error indicates the socket peer disconnected
@@ -720,6 +748,46 @@ mod tests {
         assert!(
             message.contains("instead of starting a standalone daemon"),
             "error should include the blocked action: {message}"
+        );
+        Ok(())
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[tokio::test]
+    async fn test_reconnect_daemon_keeps_retrying_nix_managed_service()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let home = tempfile::tempdir()?;
+        write_nix_managed_definition(home.path())?;
+        let socket_path = home.path().join(".capsule/capsule.sock");
+
+        reconnect_daemon_with_home(&socket_path, Some(home.path())).await;
+
+        Ok(())
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn test_reconnect_exhausted_error_reports_nix_managed_definition()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let home = tempfile::tempdir()?;
+        write_nix_managed_definition(home.path())?;
+        let error = reconnect_exhausted_error_with_home(
+            std::io::Error::new(std::io::ErrorKind::NotFound, "socket missing"),
+            Some(home.path()),
+        );
+        let message = error.to_string();
+
+        assert!(
+            message.contains("capsule daemon is managed by Nix at"),
+            "error should explain that the daemon is Nix-managed: {message}"
+        );
+        assert!(
+            message.contains("instead of waiting for automatic reconnection"),
+            "error should explain how to recover after reconnect exhaustion: {message}"
+        );
+        assert!(
+            message.contains("last connect error: socket missing"),
+            "error should preserve the final socket error: {message}"
         );
         Ok(())
     }

--- a/crates/cli/src/connect.rs
+++ b/crates/cli/src/connect.rs
@@ -91,14 +91,26 @@ fn generate_session_id() -> anyhow::Result<SessionId> {
     Ok(SessionId::from_bytes(bytes))
 }
 
-/// Ensure the daemon is running. Auto-start if needed.
+/// Ensure the daemon is ready. Auto-start standalone daemons if needed.
 fn ensure_daemon(socket_path: &Path) -> anyhow::Result<()> {
-    // Try connecting to check if daemon is alive
+    let home = crate::daemon::home_dir()?;
+    ensure_daemon_with_home(socket_path, &home)
+}
+
+fn ensure_daemon_with_home(socket_path: &Path, home: &Path) -> anyhow::Result<()> {
+    if crate::daemon::nix_managed_service_definition(home).is_some() {
+        return crate::daemon::wait_until_daemon_ready(socket_path, None).with_context(|| {
+            format!(
+                "Nix-managed daemon did not become ready at {}",
+                socket_path.display()
+            )
+        });
+    }
+
+    // Try connecting to check if daemon is alive.
     if std::os::unix::net::UnixStream::connect(socket_path).is_ok() {
         return Ok(());
     }
-
-    bail_if_nix_managed_daemon(&crate::daemon::home_dir()?, "starting a standalone daemon")?;
 
     // Spawn daemon process.
     // Intentionally detach: the daemon outlives this process and tracks
@@ -702,6 +714,30 @@ mod tests {
 
     use super::*;
 
+    fn start_hello_ack_server(socket_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+        let listener = std::os::unix::net::UnixListener::bind(socket_path)?;
+        std::thread::spawn(move || {
+            let Ok((stream, _)) = listener.accept() else {
+                return;
+            };
+            let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+            let _ = stream.set_write_timeout(Some(Duration::from_secs(5)));
+            {
+                let mut reader = std::io::BufReader::new(&stream);
+                let mut buf = Vec::new();
+                let _ = reader.read_until(b'\n', &mut buf);
+            }
+            let ack = Message::HelloAck(capsule_protocol::HelloAck {
+                build_id: crate::build_id::compute(),
+                env_var_names: vec![],
+            });
+            let mut wire = ack.to_wire();
+            wire.push(b'\n');
+            let _ = (&stream).write_all(&wire);
+        });
+        Ok(())
+    }
+
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     fn write_nix_managed_definition(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
         #[cfg(target_os = "linux")]
@@ -752,6 +788,20 @@ mod tests {
             message.contains("instead of starting a standalone daemon"),
             "error should include the blocked action: {message}"
         );
+        Ok(())
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn test_ensure_daemon_waits_for_nix_managed_service() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let home = tempfile::tempdir()?;
+        write_nix_managed_definition(home.path())?;
+        let socket_path = home.path().join("capsule.sock");
+        start_hello_ack_server(&socket_path)?;
+
+        ensure_daemon_with_home(&socket_path, home.path())?;
+
         Ok(())
     }
 

--- a/crates/cli/src/connect.rs
+++ b/crates/cli/src/connect.rs
@@ -98,6 +98,8 @@ fn ensure_daemon(socket_path: &Path) -> anyhow::Result<()> {
         return Ok(());
     }
 
+    bail_if_nix_managed_daemon(&crate::daemon::home_dir()?, "starting a standalone daemon")?;
+
     // Spawn daemon process.
     // Intentionally detach: the daemon outlives this process and tracks
     // its own PID via the lock file.
@@ -280,6 +282,8 @@ pub fn negotiate_build_id(socket_path: &Path) -> anyhow::Result<BuildIdNegotiati
 /// (standalone mode).
 fn restart_daemon(socket_path: &Path, lock_path: &Path) -> anyhow::Result<()> {
     let home = crate::daemon::home_dir()?;
+    bail_if_nix_managed_daemon(&home, "reinstalling it imperatively")?;
+
     if crate::daemon::reinstall_service_if_present(&home, socket_path)?.is_some() {
         return Ok(());
     }
@@ -348,7 +352,7 @@ async fn relay(socket_path: &Path, session_id: SessionId) -> anyhow::Result<()> 
                 Err(e) if retries >= MAX_RETRIES => return Err(e.into()),
                 Err(_) => {
                     retries += 1;
-                    reconnect_daemon(socket_path).await;
+                    reconnect_daemon(socket_path).await?;
                 }
             }
         };
@@ -378,7 +382,7 @@ async fn relay(socket_path: &Path, session_id: SessionId) -> anyhow::Result<()> 
         if retries >= MAX_RETRIES {
             return Ok(());
         }
-        reconnect_daemon(socket_path).await;
+        reconnect_daemon(socket_path).await?;
     }
 }
 
@@ -611,11 +615,25 @@ fn parse_env_meta(meta: &[u8]) -> Vec<(String, String)> {
     vars
 }
 
+fn bail_if_nix_managed_daemon(home: &Path, action: &str) -> anyhow::Result<()> {
+    if let Some(definition) = crate::daemon::nix_managed_service_definition(home) {
+        anyhow::bail!(
+            "capsule daemon is managed by Nix at {}; activate or restart the Nix-managed service/socket instead of {action}",
+            definition.display()
+        );
+    }
+    Ok(())
+}
+
 /// Wait briefly, then ensure the daemon is running for reconnection.
-async fn reconnect_daemon(socket_path: &Path) {
+async fn reconnect_daemon(socket_path: &Path) -> anyhow::Result<()> {
     tokio::time::sleep(RETRY_INTERVAL).await;
+    if let Ok(home) = crate::daemon::home_dir() {
+        bail_if_nix_managed_daemon(&home, "starting a standalone daemon")?;
+    }
     let path = socket_path.to_owned();
     let _ = tokio::task::spawn_blocking(move || ensure_daemon(&path)).await;
+    Ok(())
 }
 
 /// Returns `true` if the error indicates the socket peer disconnected
@@ -647,12 +665,63 @@ fn is_socket_error(e: &std::io::Error) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use capsule_protocol::PromptGeneration;
 
     use super::*;
 
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fn write_nix_managed_definition(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
+        #[cfg(target_os = "linux")]
+        {
+            let unit_dir = home.join(".config/systemd/user");
+            std::fs::create_dir_all(&unit_dir)?;
+            std::fs::write(
+                unit_dir.join("capsule.service"),
+                "[Service]\nEnvironment=CAPSULE_NIX_MANAGED=1\n",
+            )?;
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            let launch_agents = home.join("Library/LaunchAgents");
+            std::fs::create_dir_all(&launch_agents)?;
+            std::fs::write(
+                launch_agents.join("com.github.shuymn.capsule.plist"),
+                "<key>CAPSULE_NIX_MANAGED</key>\n<string>1</string>\n",
+            )?;
+        }
+
+        Ok(())
+    }
+
     fn test_session_id() -> SessionId {
         SessionId::from_bytes([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22])
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn test_bail_if_nix_managed_daemon_reports_definition() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let home = tempfile::tempdir()?;
+        write_nix_managed_definition(home.path())?;
+
+        let Err(error) = bail_if_nix_managed_daemon(home.path(), "starting a standalone daemon")
+        else {
+            return Err(std::io::Error::other("expected Nix-managed daemon error").into());
+        };
+        let message = error.to_string();
+
+        assert!(
+            message.contains("capsule daemon is managed by Nix at"),
+            "error should explain that the daemon is Nix-managed: {message}"
+        );
+        assert!(
+            message.contains("instead of starting a standalone daemon"),
+            "error should include the blocked action: {message}"
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/cli/src/connect.rs
+++ b/crates/cli/src/connect.rs
@@ -352,7 +352,7 @@ async fn relay(socket_path: &Path, session_id: SessionId) -> anyhow::Result<()> 
                 Err(e) if retries >= MAX_RETRIES => return Err(reconnect_exhausted_error(e)),
                 Err(_) => {
                     retries += 1;
-                    reconnect_daemon(socket_path).await;
+                    reconnect_daemon(socket_path).await?;
                 }
             }
         };
@@ -382,7 +382,7 @@ async fn relay(socket_path: &Path, session_id: SessionId) -> anyhow::Result<()> 
         if retries >= MAX_RETRIES {
             return Ok(());
         }
-        reconnect_daemon(socket_path).await;
+        reconnect_daemon(socket_path).await?;
     }
 }
 
@@ -650,18 +650,21 @@ fn reconnect_exhausted_error_with_home(
 }
 
 /// Wait briefly, then ensure the daemon is running for reconnection.
-async fn reconnect_daemon(socket_path: &Path) {
+async fn reconnect_daemon(socket_path: &Path) -> anyhow::Result<()> {
     let home = crate::daemon::home_dir().ok();
-    reconnect_daemon_with_home(socket_path, home.as_deref()).await;
+    reconnect_daemon_with_home(socket_path, home.as_deref()).await
 }
 
-async fn reconnect_daemon_with_home(socket_path: &Path, home: Option<&Path>) {
+async fn reconnect_daemon_with_home(socket_path: &Path, home: Option<&Path>) -> anyhow::Result<()> {
     tokio::time::sleep(RETRY_INTERVAL).await;
     if home.is_some_and(|home| crate::daemon::nix_managed_service_definition(home).is_some()) {
-        return;
+        return Ok(());
     }
     let path = socket_path.to_owned();
-    let _ = tokio::task::spawn_blocking(move || ensure_daemon(&path)).await;
+    tokio::task::spawn_blocking(move || ensure_daemon(&path))
+        .await
+        .context("daemon startup task failed")??;
+    Ok(())
 }
 
 /// Returns `true` if the error indicates the socket peer disconnected
@@ -760,7 +763,7 @@ mod tests {
         write_nix_managed_definition(home.path())?;
         let socket_path = home.path().join(".capsule/capsule.sock");
 
-        reconnect_daemon_with_home(&socket_path, Some(home.path())).await;
+        reconnect_daemon_with_home(&socket_path, Some(home.path())).await?;
 
         Ok(())
     }

--- a/crates/cli/src/daemon.rs
+++ b/crates/cli/src/daemon.rs
@@ -27,6 +27,8 @@ pub use service::{
 };
 pub use status::status;
 
+const SOCKET_PATH_ENV: &str = "CAPSULE_SOCKET_PATH";
+
 /// Initialize tracing subscriber if `CAPSULE_LOG` is set.
 ///
 /// Writes structured log lines to `$TMPDIR/capsule.log`. The `CAPSULE_LOG`
@@ -187,8 +189,21 @@ fn acquire_flock() -> anyhow::Result<Option<File>> {
 ///
 /// # Errors
 ///
-/// Returns an error if the base directory cannot be determined.
+/// Returns an error if the base directory cannot be determined or the
+/// `CAPSULE_SOCKET_PATH` override is empty.
 pub fn socket_path() -> anyhow::Result<PathBuf> {
+    socket_path_from_env(std::env::var_os(SOCKET_PATH_ENV))
+}
+
+fn socket_path_from_env(socket_path_env: Option<std::ffi::OsString>) -> anyhow::Result<PathBuf> {
+    if let Some(path) = socket_path_env {
+        let path = PathBuf::from(path);
+        if path.as_os_str().is_empty() {
+            anyhow::bail!("{SOCKET_PATH_ENV} must not be empty");
+        }
+        return Ok(path);
+    }
+
     Ok(capsule_dir()?.join("capsule.sock"))
 }
 
@@ -228,7 +243,7 @@ mod tests {
     use std::{
         fs::File,
         io::{BufRead as _, Write as _},
-        path::Path,
+        path::{Path, PathBuf},
         time::Duration,
     };
 
@@ -305,6 +320,27 @@ mod tests {
             let _ = (&stream).write_all(&wire);
         });
         Ok(())
+    }
+
+    #[test]
+    fn test_socket_path_uses_env_override() -> Result<(), Box<dyn std::error::Error>> {
+        let path = PathBuf::from("/tmp/capsule-custom.sock");
+
+        assert_eq!(
+            super::socket_path_from_env(Some(path.clone().into_os_string()))?,
+            path,
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_socket_path_rejects_empty_env_override() {
+        let result = super::socket_path_from_env(Some(std::ffi::OsString::new()));
+
+        assert!(
+            result.is_err(),
+            "empty CAPSULE_SOCKET_PATH should be rejected"
+        );
     }
 
     #[test]

--- a/crates/cli/src/daemon.rs
+++ b/crates/cli/src/daemon.rs
@@ -22,7 +22,9 @@ pub use service::Systemd;
 use service::launchd::LAUNCHD_SOCKET_NAME;
 #[cfg(unix)]
 pub use service::wait_until_daemon_ready;
-pub use service::{InstallOutcome, ServiceManager, reinstall_service_if_present};
+pub use service::{
+    InstallOutcome, ServiceManager, nix_managed_service_definition, reinstall_service_if_present,
+};
 pub use status::status;
 
 /// Initialize tracing subscriber if `CAPSULE_LOG` is set.

--- a/crates/cli/src/daemon/service/launchd.rs
+++ b/crates/cli/src/daemon/service/launchd.rs
@@ -385,6 +385,19 @@ mod tests {
         );
     }
 
+    #[test]
+    fn nix_managed_plist_path_detects_marker() -> Result<(), Box<dyn std::error::Error>> {
+        let home = tempfile::tempdir()?;
+        let launch_agents = home.path().join("Library/LaunchAgents");
+        std::fs::create_dir_all(&launch_agents)?;
+        let plist = launch_agents.join(format!("{LAUNCHD_LABEL}.plist"));
+        std::fs::write(&plist, super::super::NIX_MANAGED_MARKER)?;
+
+        assert_eq!(super::nix_managed_plist_path(home.path()), Some(plist));
+
+        Ok(())
+    }
+
     fn plist_without_env() -> String {
         let bin = PathBuf::from("/usr/local/bin/capsule");
         let sock = PathBuf::from("/Users/test/.capsule/capsule.sock");

--- a/crates/cli/src/daemon/service/launchd.rs
+++ b/crates/cli/src/daemon/service/launchd.rs
@@ -14,6 +14,8 @@ const LAUNCHD_LABEL: &str = "com.github.shuymn.capsule";
 /// launchd socket name matching the plist `SockServiceName`.
 pub const LAUNCHD_SOCKET_NAME: &str = "Listeners";
 
+const NIX_DARWIN_USER_LAUNCH_AGENT_DIR: &str = "/run/current-system/user/Library/LaunchAgents";
+
 /// macOS launchd service manager.
 #[cfg(target_os = "macos")]
 pub struct Launchd {
@@ -87,9 +89,10 @@ impl ServiceManager for Launchd {
         let plist_content = generate_plist(&capsule_bin, socket_path, &forwarded_env);
         let plist = plist_path_for(home);
 
-        if super::is_nix_managed_definition(&plist) {
+        if let Some(path) = nix_managed_plist_path(home) {
             anyhow::bail!(
-                "capsule daemon is managed by Nix; change your Nix configuration instead of running `capsule daemon install`"
+                "capsule daemon is managed by Nix at {}; change your Nix configuration instead of running `capsule daemon install`",
+                path.display()
             );
         }
 
@@ -120,9 +123,10 @@ impl ServiceManager for Launchd {
     fn uninstall(&self, home: &Path) -> anyhow::Result<()> {
         let plist = plist_path_for(home);
 
-        if super::is_nix_managed_definition(&plist) {
+        if let Some(path) = nix_managed_plist_path(home) {
             anyhow::bail!(
-                "capsule daemon is managed by Nix; disable the Nix module instead of running `capsule daemon uninstall`"
+                "capsule daemon is managed by Nix at {}; disable the Nix module instead of running `capsule daemon uninstall`",
+                path.display()
             );
         }
 
@@ -251,11 +255,28 @@ pub(super) fn plist_path_for(home: &Path) -> PathBuf {
         .join(format!("{LAUNCHD_LABEL}.plist"))
 }
 
+/// Return the Nix-managed launchd plist path, if one is present.
+pub(super) fn nix_managed_plist_path(home: &Path) -> Option<PathBuf> {
+    plist_definition_paths(home)
+        .into_iter()
+        .find(|path| super::is_nix_managed_definition(path))
+}
+
+fn plist_definition_paths(home: &Path) -> [PathBuf; 2] {
+    [
+        plist_path_for(home),
+        PathBuf::from(NIX_DARWIN_USER_LAUNCH_AGENT_DIR).join(format!("{LAUNCHD_LABEL}.plist")),
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
 
-    use super::{LAUNCHD_LABEL, LAUNCHD_SOCKET_NAME, generate_plist, plist_path_for};
+    use super::{
+        LAUNCHD_LABEL, LAUNCHD_SOCKET_NAME, NIX_DARWIN_USER_LAUNCH_AGENT_DIR, generate_plist,
+        plist_path_for,
+    };
 
     #[test]
     fn plist_contains_core_fields() {
@@ -346,6 +367,21 @@ mod tests {
         assert_eq!(
             path,
             PathBuf::from("/Users/test/Library/LaunchAgents/com.github.shuymn.capsule.plist")
+        );
+    }
+
+    #[test]
+    fn plist_definition_paths_include_nix_darwin_current_system_user_agent() {
+        let home = PathBuf::from("/Users/test");
+        let plist_filename = format!("{LAUNCHD_LABEL}.plist");
+        let paths = super::plist_definition_paths(&home);
+
+        assert_eq!(
+            paths,
+            [
+                plist_path_for(&home),
+                PathBuf::from(NIX_DARWIN_USER_LAUNCH_AGENT_DIR).join(plist_filename),
+            ],
         );
     }
 

--- a/crates/cli/src/daemon/service/launchd.rs
+++ b/crates/cli/src/daemon/service/launchd.rs
@@ -87,6 +87,12 @@ impl ServiceManager for Launchd {
         let plist_content = generate_plist(&capsule_bin, socket_path, &forwarded_env);
         let plist = plist_path_for(home);
 
+        if super::is_nix_managed_definition(&plist) {
+            anyhow::bail!(
+                "capsule daemon is managed by Nix; change your Nix configuration instead of running `capsule daemon install`"
+            );
+        }
+
         if let Ok(existing) = std::fs::read_to_string(&plist) {
             if existing == plist_content {
                 if super::daemon_needs_restart(socket_path) {
@@ -113,6 +119,12 @@ impl ServiceManager for Launchd {
 
     fn uninstall(&self, home: &Path) -> anyhow::Result<()> {
         let plist = plist_path_for(home);
+
+        if super::is_nix_managed_definition(&plist) {
+            anyhow::bail!(
+                "capsule daemon is managed by Nix; disable the Nix module instead of running `capsule daemon uninstall`"
+            );
+        }
 
         if !self.unload()? {
             eprintln!("warning: service unload exited with non-zero status");

--- a/crates/cli/src/daemon/service/mod.rs
+++ b/crates/cli/src/daemon/service/mod.rs
@@ -76,7 +76,8 @@ pub trait ServiceManager {
 /// as needed — then returns the [`InstallOutcome`].
 ///
 /// Returns `Ok(None)` if no service definition is installed (i.e. the daemon
-/// runs in standalone mode) or the platform is unsupported.
+/// runs in standalone mode), the platform is unsupported, or the service
+/// definition is managed declaratively by Nix.
 ///
 /// # Errors
 ///
@@ -85,20 +86,79 @@ pub fn reinstall_service_if_present(
     home: &Path,
     socket_path: &Path,
 ) -> anyhow::Result<Option<InstallOutcome>> {
+    if nix_managed_service_definition(home).is_some() {
+        return Ok(None);
+    }
+
     #[cfg(target_os = "macos")]
-    if launchd::plist_path_for(home).exists() {
-        let sm = Launchd::new(socket_path)?;
-        return Ok(Some(sm.install(home, socket_path)?));
+    {
+        let plist = launchd::plist_path_for(home);
+        if plist.exists() {
+            let sm = Launchd::new(socket_path)?;
+            return Ok(Some(sm.install(home, socket_path)?));
+        }
     }
 
     #[cfg(target_os = "linux")]
-    if systemd::service_file_path(home).exists() {
-        let sm = Systemd::new(socket_path);
-        return Ok(Some(sm.install(home, socket_path)?));
+    {
+        let service_file = systemd::service_file_path(home);
+        if service_file.exists() {
+            let sm = Systemd::new(socket_path);
+            return Ok(Some(sm.install(home, socket_path)?));
+        }
     }
 
     let _ = (home, socket_path);
     Ok(None)
+}
+
+/// Return the Nix-managed daemon definition path, if one is present.
+pub fn nix_managed_service_definition(home: &Path) -> Option<std::path::PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        let plist = launchd::plist_path_for(home);
+        if is_nix_managed_definition(&plist) {
+            return Some(plist);
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    if let Some(path) = systemd::nix_managed_service_file_path(home) {
+        return Some(path);
+    }
+
+    let _ = home;
+    None
+}
+
+const NIX_MANAGED_MARKER: &str = "CAPSULE_NIX_MANAGED";
+
+fn is_nix_managed_definition(path: &Path) -> bool {
+    definition_contains_nix_marker(path)
+        || is_nix_store_path(path)
+        || symlink_target_is_nix_store_path(path)
+        || std::fs::canonicalize(path).is_ok_and(|resolved| is_nix_store_path(&resolved))
+}
+
+fn definition_contains_nix_marker(path: &Path) -> bool {
+    std::fs::read_to_string(path).is_ok_and(|content| content.contains(NIX_MANAGED_MARKER))
+}
+
+fn symlink_target_is_nix_store_path(path: &Path) -> bool {
+    std::fs::read_link(path).is_ok_and(|target| {
+        let absolute_target = if target.is_absolute() {
+            target
+        } else if let Some(parent) = path.parent() {
+            parent.join(target)
+        } else {
+            target
+        };
+        is_nix_store_path(&absolute_target)
+    })
+}
+
+fn is_nix_store_path(path: &Path) -> bool {
+    path.starts_with("/nix/store")
 }
 
 /// Check if a running daemon needs to be restarted due to a binary update.
@@ -183,4 +243,70 @@ pub(super) fn collect_forwarded_env() -> Vec<(&'static str, String)> {
         vars.push(("XDG_CONFIG_HOME", val));
     }
     vars
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::{NIX_MANAGED_MARKER, is_nix_managed_definition};
+
+    #[cfg(unix)]
+    #[test]
+    fn test_nix_managed_definition_detects_nix_store_symlink()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let definition = dir.path().join("capsule.service");
+
+        std::os::unix::fs::symlink("/nix/store/example-capsule.service", &definition)?;
+
+        assert!(
+            is_nix_managed_definition(&definition),
+            "definition symlinked into /nix/store should be treated as Nix-managed"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_nix_managed_definition_detects_marker() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let definition = dir.path().join("com.github.shuymn.capsule.plist");
+
+        std::fs::write(
+            &definition,
+            format!("<key>{NIX_MANAGED_MARKER}</key>\n<string>1</string>\n"),
+        )?;
+
+        assert!(
+            is_nix_managed_definition(&definition),
+            "definition containing the Nix marker should be treated as Nix-managed"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_nix_managed_definition_ignores_regular_home_file()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let definition = dir.path().join("capsule.service");
+
+        std::fs::write(
+            &definition,
+            "[Service]\nExecStart=/usr/local/bin/capsule daemon\n",
+        )?;
+
+        assert!(
+            !is_nix_managed_definition(&definition),
+            "regular files outside /nix/store should remain imperatively managed"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_nix_managed_definition_ignores_missing_file() {
+        assert!(
+            !is_nix_managed_definition(Path::new("/tmp/capsule-missing.service")),
+            "missing definitions should not be treated as Nix-managed"
+        );
+    }
 }

--- a/crates/cli/src/daemon/service/mod.rs
+++ b/crates/cli/src/daemon/service/mod.rs
@@ -116,9 +116,8 @@ pub fn reinstall_service_if_present(
 pub fn nix_managed_service_definition(home: &Path) -> Option<std::path::PathBuf> {
     #[cfg(target_os = "macos")]
     {
-        let plist = launchd::plist_path_for(home);
-        if is_nix_managed_definition(&plist) {
-            return Some(plist);
+        if let Some(path) = launchd::nix_managed_plist_path(home) {
+            return Some(path);
         }
     }
 

--- a/crates/cli/src/daemon/service/systemd.rs
+++ b/crates/cli/src/daemon/service/systemd.rs
@@ -9,6 +9,10 @@ use anyhow::Context as _;
 
 use super::ServiceManager;
 
+const SERVICE_UNIT: &str = "capsule.service";
+const SOCKET_UNIT: &str = "capsule.socket";
+const SYSTEMD_USER_DIR: &str = "systemd/user";
+
 /// Linux systemd user-session service manager.
 pub struct Systemd {
     socket_path: PathBuf,
@@ -25,6 +29,13 @@ impl Systemd {
 
 impl ServiceManager for Systemd {
     fn install(&self, home: &Path, socket_path: &Path) -> anyhow::Result<super::InstallOutcome> {
+        if let Some(path) = nix_managed_service_file_path(home) {
+            anyhow::bail!(
+                "capsule daemon is managed by Nix at {}; change your Nix configuration instead of running `capsule daemon install`",
+                path.display()
+            );
+        }
+
         let capsule_bin = std::env::current_exe().context("cannot find capsule binary")?;
         let forwarded_env = super::collect_forwarded_env();
 
@@ -48,7 +59,7 @@ impl ServiceManager for Systemd {
         }
 
         // Stop before rewriting unit files.
-        let _ = systemctl(&["stop", "capsule.socket", "capsule.service"]);
+        let _ = systemctl(&["stop", SOCKET_UNIT, SERVICE_UNIT]);
 
         let unit_dir = unit_dir(home);
         std::fs::create_dir_all(&unit_dir)
@@ -60,7 +71,7 @@ impl ServiceManager for Systemd {
             .with_context(|| format!("failed to write {}", socket_file.display()))?;
 
         systemctl(&["daemon-reload"]).context("systemctl daemon-reload failed")?;
-        systemctl(&["enable", "--now", "capsule.socket"])
+        systemctl(&["enable", "--now", SOCKET_UNIT])
             .context("systemctl enable --now capsule.socket failed")?;
 
         super::wait_until_daemon_ready(&self.socket_path, None)
@@ -70,10 +81,15 @@ impl ServiceManager for Systemd {
     }
 
     fn uninstall(&self, home: &Path) -> anyhow::Result<()> {
-        systemctl(&["stop", "capsule.socket", "capsule.service"])
-            .context("systemctl stop failed")?;
-        systemctl(&["disable", "capsule.socket", "capsule.service"])
-            .context("systemctl disable failed")?;
+        if let Some(path) = nix_managed_service_file_path(home) {
+            anyhow::bail!(
+                "capsule daemon is managed by Nix at {}; disable the Nix module instead of running `capsule daemon uninstall`",
+                path.display()
+            );
+        }
+
+        systemctl(&["stop", SOCKET_UNIT, SERVICE_UNIT]).context("systemctl stop failed")?;
+        systemctl(&["disable", SOCKET_UNIT, SERVICE_UNIT]).context("systemctl disable failed")?;
 
         for path in [service_file_path(home), socket_file_path(home)] {
             match std::fs::remove_file(&path) {
@@ -93,7 +109,7 @@ impl ServiceManager for Systemd {
     }
 
     fn restart(&self) -> anyhow::Result<()> {
-        systemctl(&["restart", "capsule.service"]).context("systemctl restart failed")?;
+        systemctl(&["restart", SERVICE_UNIT]).context("systemctl restart failed")?;
         let expected = crate::build_id::compute();
         super::wait_until_daemon_ready(&self.socket_path, expected.as_ref())
             .context("daemon did not become ready after restart")?;
@@ -151,19 +167,61 @@ fn generate_socket_unit(socket_path: &Path) -> String {
     )
 }
 
+/// Return the Nix-managed service definition path, if one is present.
+pub(super) fn nix_managed_service_file_path(home: &Path) -> Option<PathBuf> {
+    service_definition_paths(home)
+        .into_iter()
+        .find(|path| super::is_nix_managed_definition(path))
+}
+
+/// Candidate service definition paths owned by capsule, Home Manager, or NixOS.
+fn service_definition_paths(home: &Path) -> Vec<PathBuf> {
+    let mut paths = vec![service_file_path(home)];
+
+    if let Some(xdg_config_home) = std::env::var_os("XDG_CONFIG_HOME") {
+        let xdg_config_path = PathBuf::from(xdg_config_home)
+            .join(SYSTEMD_USER_DIR)
+            .join(SERVICE_UNIT);
+        if !paths.contains(&xdg_config_path) {
+            paths.push(xdg_config_path);
+        }
+    }
+
+    paths.push(data_service_file_path(home));
+    paths.push(
+        PathBuf::from("/etc")
+            .join(SYSTEMD_USER_DIR)
+            .join(SERVICE_UNIT),
+    );
+    paths
+}
+
 /// `~/.config/systemd/user/` directory.
 fn unit_dir(home: &Path) -> PathBuf {
-    home.join(".config/systemd/user")
+    home.join(".config").join(SYSTEMD_USER_DIR)
+}
+
+/// `$XDG_DATA_HOME/systemd/user/` directory.
+fn data_unit_dir(home: &Path) -> PathBuf {
+    std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join(".local/share"))
+        .join(SYSTEMD_USER_DIR)
 }
 
 /// Path to the `.service` unit file.
 pub(super) fn service_file_path(home: &Path) -> PathBuf {
-    unit_dir(home).join("capsule.service")
+    unit_dir(home).join(SERVICE_UNIT)
+}
+
+/// Path to the Home Manager-generated `.service` unit file.
+fn data_service_file_path(home: &Path) -> PathBuf {
+    data_unit_dir(home).join(SERVICE_UNIT)
 }
 
 /// Path to the `.socket` unit file.
 fn socket_file_path(home: &Path) -> PathBuf {
-    unit_dir(home).join("capsule.socket")
+    unit_dir(home).join(SOCKET_UNIT)
 }
 
 #[cfg(test)]

--- a/crates/cli/src/daemon/service/systemd.rs
+++ b/crates/cli/src/daemon/service/systemd.rs
@@ -119,15 +119,19 @@ impl ServiceManager for Systemd {
 
 /// Run `systemctl --user <args>`.
 fn systemctl(args: &[&str]) -> anyhow::Result<()> {
-    let status = std::process::Command::new("systemctl")
-        .arg("--user")
-        .args(args)
+    let status = systemctl_command(args)
         .status()
         .context("failed to run systemctl")?;
     if !status.success() {
         anyhow::bail!("systemctl --user {} failed with {status}", args.join(" "));
     }
     Ok(())
+}
+
+fn systemctl_command(args: &[&str]) -> std::process::Command {
+    let mut command = std::process::Command::new("systemctl");
+    command.arg("--user").args(args);
+    command
 }
 
 /// Generate the `.service` unit file content.
@@ -176,19 +180,40 @@ pub(super) fn nix_managed_service_file_path(home: &Path) -> Option<PathBuf> {
 
 /// Candidate service definition paths owned by capsule, Home Manager, or NixOS.
 fn service_definition_paths(home: &Path) -> Vec<PathBuf> {
-    let mut paths = vec![service_file_path(home)];
+    service_definition_paths_with_env(
+        home,
+        std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from),
+        std::env::var_os("XDG_DATA_HOME").map(PathBuf::from),
+        systemctl_fragment_path(),
+    )
+}
 
-    if let Some(xdg_config_home) = std::env::var_os("XDG_CONFIG_HOME") {
-        let xdg_config_path = PathBuf::from(xdg_config_home)
-            .join(SYSTEMD_USER_DIR)
-            .join(SERVICE_UNIT);
-        if !paths.contains(&xdg_config_path) {
-            paths.push(xdg_config_path);
-        }
+fn service_definition_paths_with_env(
+    home: &Path,
+    xdg_config_home: Option<PathBuf>,
+    xdg_data_home: Option<PathBuf>,
+    fragment_path: Option<PathBuf>,
+) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    push_unique_path(&mut paths, service_file_path(home));
+
+    if let Some(fragment_path) = fragment_path {
+        push_unique_path(&mut paths, fragment_path);
     }
 
-    paths.push(data_service_file_path(home));
-    paths.push(
+    if let Some(xdg_config_home) = xdg_config_home {
+        push_unique_path(
+            &mut paths,
+            xdg_config_home.join(SYSTEMD_USER_DIR).join(SERVICE_UNIT),
+        );
+    }
+
+    push_unique_path(
+        &mut paths,
+        data_unit_dir(home, xdg_data_home).join(SERVICE_UNIT),
+    );
+    push_unique_path(
+        &mut paths,
         PathBuf::from("/etc")
             .join(SYSTEMD_USER_DIR)
             .join(SERVICE_UNIT),
@@ -196,15 +221,41 @@ fn service_definition_paths(home: &Path) -> Vec<PathBuf> {
     paths
 }
 
+fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    if !paths.contains(&path) {
+        paths.push(path);
+    }
+}
+
+fn systemctl_fragment_path() -> Option<PathBuf> {
+    let output = systemctl_command(&["show", SERVICE_UNIT, "--property=FragmentPath", "--value"])
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    stdout
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .and_then(|line| {
+            let path = PathBuf::from(line);
+            path.is_absolute().then_some(path)
+        })
+}
+
 /// `~/.config/systemd/user/` directory.
 fn unit_dir(home: &Path) -> PathBuf {
     home.join(".config").join(SYSTEMD_USER_DIR)
 }
 
-/// `$XDG_DATA_HOME/systemd/user/` directory.
-fn data_unit_dir(home: &Path) -> PathBuf {
-    std::env::var_os("XDG_DATA_HOME")
-        .map(PathBuf::from)
+/// `$XDG_DATA_HOME/systemd/user/` directory (Home Manager's default unit
+/// location), falling back to `~/.local/share/systemd/user/`.
+fn data_unit_dir(home: &Path, xdg_data_home: Option<PathBuf>) -> PathBuf {
+    xdg_data_home
         .unwrap_or_else(|| home.join(".local/share"))
         .join(SYSTEMD_USER_DIR)
 }
@@ -212,11 +263,6 @@ fn data_unit_dir(home: &Path) -> PathBuf {
 /// Path to the `.service` unit file.
 pub(super) fn service_file_path(home: &Path) -> PathBuf {
     unit_dir(home).join(SERVICE_UNIT)
-}
-
-/// Path to the Home Manager-generated `.service` unit file.
-fn data_service_file_path(home: &Path) -> PathBuf {
-    data_unit_dir(home).join(SERVICE_UNIT)
 }
 
 /// Path to the `.socket` unit file.
@@ -310,6 +356,88 @@ mod tests {
         assert_eq!(
             path,
             PathBuf::from("/home/user/.config/systemd/user/capsule.socket")
+        );
+    }
+
+    #[test]
+    fn service_definition_paths_defaults_to_home_config_and_etc() {
+        let home = PathBuf::from("/home/user");
+        let paths = super::service_definition_paths_with_env(&home, None, None, None);
+        assert_eq!(
+            paths,
+            vec![
+                PathBuf::from("/home/user/.config/systemd/user/capsule.service"),
+                PathBuf::from("/home/user/.local/share/systemd/user/capsule.service"),
+                PathBuf::from("/etc/systemd/user/capsule.service"),
+            ]
+        );
+    }
+
+    #[test]
+    fn service_definition_paths_includes_xdg_config_home_override() {
+        let home = PathBuf::from("/home/user");
+        let paths = super::service_definition_paths_with_env(
+            &home,
+            Some(PathBuf::from("/custom/config")),
+            None,
+            None,
+        );
+        assert!(
+            paths.contains(&PathBuf::from(
+                "/custom/config/systemd/user/capsule.service"
+            )),
+            "should discover the XDG_CONFIG_HOME unit path: {paths:?}"
+        );
+    }
+
+    #[test]
+    fn service_definition_paths_uses_xdg_data_home_for_home_manager_units() {
+        let home = PathBuf::from("/home/user");
+        let paths = super::service_definition_paths_with_env(
+            &home,
+            None,
+            Some(PathBuf::from("/custom/data")),
+            None,
+        );
+        assert!(
+            paths.contains(&PathBuf::from("/custom/data/systemd/user/capsule.service")),
+            "should discover the XDG_DATA_HOME (Home Manager) unit path: {paths:?}"
+        );
+        assert!(
+            !paths.contains(&PathBuf::from(
+                "/home/user/.local/share/systemd/user/capsule.service"
+            )),
+            "an explicit XDG_DATA_HOME should replace the default data dir: {paths:?}"
+        );
+    }
+
+    #[test]
+    fn service_definition_paths_includes_systemctl_fragment_path() {
+        let home = PathBuf::from("/home/user");
+        let fragment = PathBuf::from("/nix/store/hash-capsule/systemd/user/capsule.service");
+        let paths =
+            super::service_definition_paths_with_env(&home, None, None, Some(fragment.clone()));
+        assert!(
+            paths.contains(&fragment),
+            "should discover the systemctl FragmentPath unit path: {paths:?}"
+        );
+    }
+
+    #[test]
+    fn service_definition_paths_deduplicates_candidates() {
+        let home = PathBuf::from("/home/user");
+        let default_config = PathBuf::from("/home/user/.config");
+        let fragment = PathBuf::from("/home/user/.config/systemd/user/capsule.service");
+        let paths = super::service_definition_paths_with_env(
+            &home,
+            Some(default_config),
+            None,
+            Some(fragment.clone()),
+        );
+        let occurrences = paths.iter().filter(|path| **path == fragment).count();
+        assert_eq!(
+            occurrences, 1,
+            "candidates equal to the default unit path should be de-duplicated: {paths:?}"
         );
     }
 

--- a/crates/core/src/module/git.rs
+++ b/crates/core/src/module/git.rs
@@ -7,6 +7,32 @@ use std::{
     process::Command,
 };
 
+const GIT_LOCAL_ENV_VARS: &[&str] = &[
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_CONFIG",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_CONFIG_COUNT",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_IMPLICIT_WORK_TREE",
+    "GIT_GRAFT_FILE",
+    "GIT_INDEX_FILE",
+    "GIT_NO_REPLACE_OBJECTS",
+    "GIT_REPLACE_REF_BASE",
+    "GIT_PREFIX",
+    "GIT_SHALLOW_FILE",
+    "GIT_COMMON_DIR",
+];
+
+macro_rules! clear_git_local_env {
+    ($cmd:expr) => {
+        for &name in GIT_LOCAL_ENV_VARS {
+            ($cmd).env_remove(name);
+        }
+    };
+}
+
 use super::{Module, ModuleOutput, ModuleSpeed, RenderContext};
 use crate::{
     render::style::{Color, ColorMap, Style},
@@ -143,6 +169,7 @@ impl sealed::Sealed for CommandGitProvider {}
 impl GitProvider for CommandGitProvider {
     fn status(&self, cwd: &Path, path_env: Option<&str>) -> Result<Option<GitStatus>, GitError> {
         let mut cmd = Command::new("git");
+        clear_git_local_env!(&mut cmd);
         cmd.args(["status", "--porcelain=v2", "--branch", "--show-stash"])
             .current_dir(cwd)
             .stderr(std::process::Stdio::null());
@@ -176,6 +203,7 @@ async fn command_git_status_async(
     path_env: Option<&str>,
 ) -> Result<Option<GitStatus>, GitError> {
     let mut cmd = tokio::process::Command::new("git");
+    clear_git_local_env!(&mut cmd);
     cmd.kill_on_drop(true)
         .args(["status", "--porcelain=v2", "--branch", "--show-stash"])
         .current_dir(cwd)

--- a/crates/core/src/module/git/tests.rs
+++ b/crates/core/src/module/git/tests.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use super::*;
 use crate::{render::layout::display_width, test_utils::contains_style_sequence};
@@ -483,33 +483,102 @@ fn test_module_speed_is_slow() {
 
 // -- Integration test with real git --
 
+const GIT_ENV_REGRESSION_CHILD: &str = "CAPSULE_GIT_ENV_REGRESSION_CHILD";
+const GIT_ENV_REGRESSION_CWD: &str = "CAPSULE_GIT_ENV_REGRESSION_CWD";
+const GIT_ENV_REGRESSION_MARKER: &str = "capsule_git_env_regression_child_success";
+
+fn test_git_command() -> Command {
+    let mut command = Command::new("git");
+    clear_git_local_env!(&mut command);
+    command
+}
+
 fn staged_git_repo() -> Result<tempfile::TempDir, Box<dyn std::error::Error>> {
     let dir = tempfile::tempdir()?;
     let path = dir.path();
 
-    let init = Command::new("git")
+    let init = test_git_command()
         .args(["init", "-b", "main"])
         .current_dir(path)
         .output()?;
     assert!(init.status.success(), "git init failed");
 
-    Command::new("git")
+    test_git_command()
         .args(["config", "user.name", "test"])
         .current_dir(path)
         .output()?;
-    Command::new("git")
+    test_git_command()
         .args(["config", "user.email", "test@test.com"])
         .current_dir(path)
         .output()?;
 
     std::fs::write(path.join("hello.txt"), "hello")?;
-    let add = Command::new("git")
+    let add = test_git_command()
         .args(["add", "hello.txt"])
         .current_dir(path)
         .output()?;
     assert!(add.status.success(), "git add failed");
 
     Ok(dir)
+}
+
+async fn run_git_env_regression_child_if_requested() -> Result<bool, Box<dyn std::error::Error>> {
+    if std::env::var(GIT_ENV_REGRESSION_CHILD).ok().as_deref() != Some("1") {
+        return Ok(false);
+    }
+
+    let cwd = PathBuf::from(std::env::var(GIT_ENV_REGRESSION_CWD)?);
+    let sync_status = CommandGitProvider.status(&cwd, None)?;
+    assert!(
+        sync_status.is_none(),
+        "sync git status should use cwd, not inherited Git env"
+    );
+
+    let async_status = CommandGitProvider.status_async(cwd, None).await?;
+    assert!(
+        async_status.is_none(),
+        "async git status should use cwd, not inherited Git env"
+    );
+
+    println!("{GIT_ENV_REGRESSION_MARKER}");
+    Ok(true)
+}
+
+fn run_git_env_regression_child(test_name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let polluted_repo = staged_git_repo()?;
+    let non_repo = tempfile::tempdir()?;
+    let output = Command::new(std::env::current_exe()?)
+        .args(["--exact", test_name, "--nocapture"])
+        .env(GIT_ENV_REGRESSION_CHILD, "1")
+        .env(GIT_ENV_REGRESSION_CWD, non_repo.path())
+        .env("GIT_DIR", polluted_repo.path().join(".git"))
+        .env("GIT_WORK_TREE", polluted_repo.path())
+        .output()?;
+
+    let child_stdout = String::from_utf8_lossy(&output.stdout);
+    let child_stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "child regression test failed\nstdout:\n{child_stdout}\nstderr:\n{child_stderr}"
+    );
+    assert!(
+        child_stdout.contains(GIT_ENV_REGRESSION_MARKER),
+        "child regression test did not run\nstdout:\n{child_stdout}\nstderr:\n{child_stderr}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_command_git_provider_ignores_git_local_env() -> Result<(), Box<dyn std::error::Error>>
+{
+    if run_git_env_regression_child_if_requested().await? {
+        return Ok(());
+    }
+
+    run_git_env_regression_child(
+        "module::git::tests::test_command_git_provider_ignores_git_local_env",
+    )
 }
 
 #[test]

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,69 @@
+{
+  "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783134515,
+        "narHash": "sha256-qMoZazubXlXUD9k/syJ/aiWC4X4g73mwVmZ7Z4+rdpM=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "b885baad531fa3d3beae2ba9a0712d22974d8016",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781761792,
+        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
+        "owner": "LnL7",
+        "repo": "nix-darwin",
+        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "LnL7",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782948114,
+        "narHash": "sha256-AXmz9ho4Lud5CsbrZsuSVwpQZ4o5FgZ1chxBn5cJ8+0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9e92285f211dad236540fd617d7e30e0b99bc0e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nix-darwin": "nix-darwin",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,241 @@
+{
+  description = "capsule prompt engine";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nix-darwin = {
+      url = "github:LnL7/nix-darwin";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      home-manager,
+      nix-darwin,
+    }:
+    let
+      inherit (nixpkgs) lib;
+
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forAllSystems = lib.genAttrs systems;
+      pkgsFor = system: import nixpkgs { inherit system; };
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+          capsule = pkgs.callPackage ./nix/package.nix { };
+        in
+        {
+          inherit capsule;
+          default = capsule;
+        }
+      );
+
+      apps = forAllSystems (system: {
+        capsule = {
+          type = "app";
+          program = "${self.packages.${system}.capsule}/bin/capsule";
+          meta.description = "Run capsule";
+        };
+        default = self.apps.${system}.capsule;
+      });
+
+      checks = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+          inherit (pkgs.stdenv.hostPlatform) isDarwin isLinux;
+
+          hmConfig = home-manager.lib.homeManagerConfiguration {
+            inherit pkgs;
+            modules = [
+              self.homeManagerModules.default
+              {
+                programs.capsule = {
+                  enable = true;
+                  daemon.enable = true;
+                  package = self.packages.${system}.capsule;
+                };
+                home = {
+                  username = "capsule";
+                  homeDirectory = if isDarwin then "/Users/capsule" else "/home/capsule";
+                  stateVersion = "26.05";
+                };
+              }
+            ];
+          };
+
+          nixosModuleEval =
+            let
+              eval = lib.nixosSystem {
+                inherit system;
+                modules = [
+                  self.nixosModules.default
+                  {
+                    programs.capsule = {
+                      enable = true;
+                      daemon.enable = true;
+                      package = self.packages.${system}.capsule;
+                    };
+                    system.stateVersion = "26.05";
+                  }
+                ];
+              };
+            in
+            {
+              listenStream = builtins.elemAt eval.config.systemd.user.sockets.capsule.listenStreams 0;
+              socketMode = eval.config.systemd.user.sockets.capsule.socketConfig.SocketMode;
+              execStart = eval.config.systemd.user.services.capsule.serviceConfig.ExecStart;
+              nixManaged =
+                if
+                  builtins.elem "CAPSULE_NIX_MANAGED=1" eval.config.systemd.user.services.capsule.serviceConfig.Environment
+                then
+                  "1"
+                else
+                  "0";
+            };
+
+          darwinModuleEval =
+            let
+              eval = nix-darwin.lib.darwinSystem {
+                inherit system;
+                modules = [
+                  self.darwinModules.default
+                  {
+                    programs.capsule = {
+                      enable = true;
+                      daemon.enable = true;
+                      package = self.packages.${system}.capsule;
+                    };
+                    system.primaryUser = "capsule";
+                    users.users.capsule.home = "/Users/capsule";
+                    system.stateVersion = 6;
+                  }
+                ];
+              };
+            in
+            {
+              socketPath = eval.config.launchd.user.agents.capsule.serviceConfig.Sockets.Listeners.SockPathName;
+              sockPathMode = eval.config.launchd.user.agents.capsule.serviceConfig.Sockets.Listeners.SockPathMode;
+              command = eval.config.launchd.user.agents.capsule.command;
+              nixManaged =
+                eval.config.launchd.user.agents.capsule.serviceConfig.EnvironmentVariables.CAPSULE_NIX_MANAGED;
+            };
+        in
+        {
+          package = self.packages.${system}.capsule;
+
+          home-manager-module =
+            pkgs.runCommandLocal "capsule-home-manager-module-check"
+              {
+                socketPath =
+                  if isDarwin then
+                    hmConfig.config.launchd.agents.capsule.config.Sockets.Listeners.SockPathName
+                  else
+                    hmConfig.config.systemd.user.sockets.capsule.Socket.ListenStream;
+                execStart =
+                  if isDarwin then
+                    builtins.concatStringsSep " " hmConfig.config.launchd.agents.capsule.config.ProgramArguments
+                  else
+                    hmConfig.config.systemd.user.services.capsule.Service.ExecStart;
+                nixManaged =
+                  if isDarwin then
+                    hmConfig.config.launchd.agents.capsule.config.EnvironmentVariables.CAPSULE_NIX_MANAGED
+                  else if
+                    builtins.elem "CAPSULE_NIX_MANAGED=1" hmConfig.config.systemd.user.services.capsule.Service.Environment
+                  then
+                    "1"
+                  else
+                    "0";
+              }
+              ''
+                test -n "$socketPath"
+                test "$nixManaged" = "1"
+                case "$execStart" in
+                  *"capsule daemon"*) ;;
+                  *) echo "unexpected ExecStart/ProgramArguments: $execStart" >&2; exit 1 ;;
+                esac
+                touch "$out"
+              '';
+        }
+        // lib.optionalAttrs isLinux {
+          nixos-module =
+            pkgs.runCommandLocal "capsule-nixos-module-check"
+              {
+                inherit (nixosModuleEval)
+                  listenStream
+                  socketMode
+                  execStart
+                  nixManaged
+                  ;
+              }
+              ''
+                test "$listenStream" = "%h/.capsule/capsule.sock"
+                test "$socketMode" = "0700"
+                test "$nixManaged" = "1"
+                case "$execStart" in
+                  *"capsule daemon"*) ;;
+                  *) echo "unexpected ExecStart: $execStart" >&2; exit 1 ;;
+                esac
+                touch "$out"
+              '';
+        }
+        // lib.optionalAttrs isDarwin {
+          darwin-module =
+            pkgs.runCommandLocal "capsule-darwin-module-check"
+              {
+                inherit (darwinModuleEval)
+                  socketPath
+                  sockPathMode
+                  command
+                  nixManaged
+                  ;
+              }
+              ''
+                test "$socketPath" = "/Users/capsule/.capsule/capsule.sock"
+                test "$sockPathMode" = "448"
+                test "$nixManaged" = "1"
+                case "$command" in
+                  *"capsule daemon"*) ;;
+                  *) echo "unexpected command: $command" >&2; exit 1 ;;
+                esac
+                touch "$out"
+              '';
+        }
+      );
+
+      homeManagerModules = {
+        capsule = ./nix/modules/home-manager.nix;
+        default = self.homeManagerModules.capsule;
+      };
+
+      nixosModules = {
+        capsule = ./nix/modules/nixos.nix;
+        default = self.nixosModules.capsule;
+      };
+
+      darwinModules = {
+        capsule = ./nix/modules/darwin.nix;
+        default = self.darwinModules.capsule;
+      };
+
+      formatter = forAllSystems (system: (pkgsFor system).nixfmt);
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,11 @@
 {
   description = "capsule prompt engine";
 
+  nixConfig = {
+    extra-substituters = [ "https://shuymn.cachix.org" ];
+    extra-trusted-public-keys = [ "shuymn.cachix.org-1:bUcNU5/B3gNbM7htHCYmKVVb1bUwNx2vc2W4aOJlloQ=" ];
+  };
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 

--- a/flake.nix
+++ b/flake.nix
@@ -103,7 +103,10 @@
                   {
                     programs.capsule = {
                       enable = true;
-                      daemon.enable = true;
+                      daemon = {
+                        enable = true;
+                        socketPath = capsuleSocketPath;
+                      };
                       package = self.packages.${system}.capsule;
                     };
                     system.stateVersion = "26.05";
@@ -115,6 +118,12 @@
               listenStream = builtins.elemAt eval.config.systemd.user.sockets.capsule.listenStreams 0;
               socketMode = eval.config.systemd.user.sockets.capsule.socketConfig.SocketMode;
               execStart = eval.config.systemd.user.services.capsule.serviceConfig.ExecStart;
+              sessionSocketPath = eval.config.environment.sessionVariables.${socketPathEnv};
+              daemonSocketPath = lib.removePrefix socketPathEnvPrefix (
+                lib.findFirst (
+                  value: lib.hasPrefix socketPathEnvPrefix value
+                ) "" eval.config.systemd.user.services.capsule.serviceConfig.Environment
+              );
               nixManaged =
                 if
                   builtins.elem "CAPSULE_NIX_MANAGED=1" eval.config.systemd.user.services.capsule.serviceConfig.Environment
@@ -133,11 +142,14 @@
                   {
                     programs.capsule = {
                       enable = true;
-                      daemon.enable = true;
+                      daemon = {
+                        enable = true;
+                        socketPath = capsuleSocketPath;
+                      };
                       package = self.packages.${system}.capsule;
                     };
                     system.primaryUser = "capsule";
-                    users.users.capsule.home = "/Users/capsule";
+                    users.users.capsule.home = capsuleHome;
                     system.stateVersion = 6;
                   }
                 ];
@@ -147,6 +159,9 @@
               socketPath = eval.config.launchd.user.agents.capsule.serviceConfig.Sockets.Listeners.SockPathName;
               sockPathMode = eval.config.launchd.user.agents.capsule.serviceConfig.Sockets.Listeners.SockPathMode;
               command = eval.config.launchd.user.agents.capsule.command;
+              sessionSocketPath = eval.config.environment.variables.${socketPathEnv};
+              daemonSocketPath =
+                eval.config.launchd.user.agents.capsule.serviceConfig.EnvironmentVariables.${socketPathEnv};
               nixManaged =
                 eval.config.launchd.user.agents.capsule.serviceConfig.EnvironmentVariables.CAPSULE_NIX_MANAGED;
             };
@@ -207,11 +222,16 @@
                   listenStream
                   socketMode
                   execStart
+                  sessionSocketPath
+                  daemonSocketPath
                   nixManaged
                   ;
+                expectedSocketPath = capsuleSocketPath;
               }
               ''
-                test "$listenStream" = "%h/.capsule/capsule.sock"
+                test "$listenStream" = "$expectedSocketPath"
+                test "$sessionSocketPath" = "$expectedSocketPath"
+                test "$daemonSocketPath" = "$expectedSocketPath"
                 test "$socketMode" = "0700"
                 test "$nixManaged" = "1"
                 case "$execStart" in
@@ -229,11 +249,16 @@
                   socketPath
                   sockPathMode
                   command
+                  sessionSocketPath
+                  daemonSocketPath
                   nixManaged
                   ;
+                expectedSocketPath = capsuleSocketPath;
               }
               ''
-                test "$socketPath" = "/Users/capsule/.capsule/capsule.sock"
+                test "$socketPath" = "$expectedSocketPath"
+                test "$sessionSocketPath" = "$expectedSocketPath"
+                test "$daemonSocketPath" = "$expectedSocketPath"
                 test "$sockPathMode" = "448"
                 test "$nixManaged" = "1"
                 case "$command" in

--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,10 @@
         let
           pkgs = pkgsFor system;
           inherit (pkgs.stdenv.hostPlatform) isDarwin isLinux;
+          capsuleHome = if isDarwin then "/Users/capsule" else "/home/capsule";
+          capsuleSocketPath = "${capsuleHome}/.cache/capsule/custom.sock";
+          socketPathEnv = "CAPSULE_SOCKET_PATH";
+          socketPathEnvPrefix = "${socketPathEnv}=";
 
           hmConfig = home-manager.lib.homeManagerConfiguration {
             inherit pkgs;
@@ -75,12 +79,15 @@
               {
                 programs.capsule = {
                   enable = true;
-                  daemon.enable = true;
+                  daemon = {
+                    enable = true;
+                    socketPath = capsuleSocketPath;
+                  };
                   package = self.packages.${system}.capsule;
                 };
                 home = {
                   username = "capsule";
-                  homeDirectory = if isDarwin then "/Users/capsule" else "/home/capsule";
+                  homeDirectory = capsuleHome;
                   stateVersion = "26.05";
                 };
               }
@@ -169,10 +176,22 @@
                     "1"
                   else
                     "0";
+                sessionSocketPath = hmConfig.config.home.sessionVariables.${socketPathEnv};
+                daemonSocketPath =
+                  if isDarwin then
+                    hmConfig.config.launchd.agents.capsule.config.EnvironmentVariables.${socketPathEnv}
+                  else
+                    lib.removePrefix socketPathEnvPrefix (
+                      lib.findFirst (
+                        value: lib.hasPrefix socketPathEnvPrefix value
+                      ) "" hmConfig.config.systemd.user.services.capsule.Service.Environment
+                    );
               }
               ''
                 test -n "$socketPath"
                 test "$nixManaged" = "1"
+                test "$sessionSocketPath" = "$socketPath"
+                test "$daemonSocketPath" = "$socketPath"
                 case "$execStart" in
                   *"capsule daemon"*) ;;
                   *) echo "unexpected ExecStart/ProgramArguments: $execStart" >&2; exit 1 ;;

--- a/nix/modules/darwin.nix
+++ b/nix/modules/darwin.nix
@@ -1,0 +1,82 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.capsule;
+  primaryUser = if config.system.primaryUser == null then "" else config.system.primaryUser;
+  socketDir = builtins.dirOf cfg.daemon.socketPath;
+  daemonEnvironment = cfg.daemon.environment // {
+    CAPSULE_NIX_MANAGED = "1";
+  };
+in
+{
+  options.programs.capsule = {
+    enable = lib.mkEnableOption "capsule prompt engine";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.callPackage ../package.nix { };
+      defaultText = lib.literalExpression "pkgs.callPackage ./nix/package.nix { }";
+      description = "capsule package to install.";
+    };
+
+    daemon = {
+      enable = lib.mkEnableOption "capsule daemon managed by nix-darwin launchd";
+
+      socketPath = lib.mkOption {
+        type = lib.types.str;
+        default = "${config.system.primaryUserHome}/.capsule/capsule.sock";
+        defaultText = lib.literalExpression ''"${config.system.primaryUserHome}/.capsule/capsule.sock"'';
+        description = "Unix-domain socket path used by capsule's shell relay.";
+      };
+
+      environment = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = {
+          XDG_CONFIG_HOME = "${config.system.primaryUserHome}/.config";
+        };
+        defaultText = lib.literalExpression ''{ XDG_CONFIG_HOME = "${config.system.primaryUserHome}/.config"; }'';
+        description = "Environment variables passed to the socket-activated daemon.";
+      };
+    };
+  };
+
+  config = lib.mkMerge [
+    {
+      assertions = [
+        {
+          assertion = !cfg.daemon.enable || cfg.enable;
+          message = "programs.capsule.daemon.enable requires programs.capsule.enable.";
+        }
+      ];
+    }
+
+    (lib.mkIf cfg.enable {
+      environment.systemPackages = [ cfg.package ];
+    })
+
+    (lib.mkIf (cfg.enable && cfg.daemon.enable) {
+      system.requiresPrimaryUser = [ "programs.capsule.daemon.enable" ];
+
+      system.activationScripts.userLaunchd.text = lib.mkBefore ''
+        sudo --user=${lib.escapeShellArg primaryUser} -- mkdir -m 700 -p ${lib.escapeShellArg socketDir}
+      '';
+
+      launchd.user.agents.capsule = {
+        command = "${lib.getExe cfg.package} daemon";
+        serviceConfig = {
+          Label = "com.github.shuymn.capsule";
+          EnvironmentVariables = daemonEnvironment;
+          Sockets.Listeners = {
+            SockPathName = cfg.daemon.socketPath;
+            SockPathMode = 448;
+          };
+        };
+      };
+    })
+  ];
+}

--- a/nix/modules/darwin.nix
+++ b/nix/modules/darwin.nix
@@ -9,9 +9,15 @@ let
   cfg = config.programs.capsule;
   primaryUser = if config.system.primaryUser == null then "" else config.system.primaryUser;
   socketDir = builtins.dirOf cfg.daemon.socketPath;
-  daemonEnvironment = cfg.daemon.environment // {
-    CAPSULE_NIX_MANAGED = "1";
+  socketPathEnvironment = {
+    CAPSULE_SOCKET_PATH = cfg.daemon.socketPath;
   };
+  daemonEnvironment =
+    cfg.daemon.environment
+    // socketPathEnvironment
+    // {
+      CAPSULE_NIX_MANAGED = "1";
+    };
 in
 {
   options.programs.capsule = {
@@ -28,7 +34,7 @@ in
       enable = lib.mkEnableOption "capsule daemon managed by nix-darwin launchd";
 
       socketPath = lib.mkOption {
-        type = lib.types.str;
+        type = lib.types.nonEmptyStr;
         default = "${config.system.primaryUserHome}/.capsule/capsule.sock";
         defaultText = lib.literalExpression ''"${config.system.primaryUserHome}/.capsule/capsule.sock"'';
         description = "Unix-domain socket path used by capsule's shell relay.";
@@ -60,6 +66,8 @@ in
     })
 
     (lib.mkIf (cfg.enable && cfg.daemon.enable) {
+      environment.variables = socketPathEnvironment;
+
       system.requiresPrimaryUser = [ "programs.capsule.daemon.enable" ];
 
       system.activationScripts.userLaunchd.text = lib.mkBefore ''

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -9,9 +9,15 @@ let
   cfg = config.programs.capsule;
   inherit (pkgs.stdenv.hostPlatform) isDarwin isLinux;
   socketDir = builtins.dirOf cfg.daemon.socketPath;
-  daemonEnvironment = cfg.daemon.environment // {
-    CAPSULE_NIX_MANAGED = "1";
+  socketPathEnvironment = {
+    CAPSULE_SOCKET_PATH = cfg.daemon.socketPath;
   };
+  daemonEnvironment =
+    cfg.daemon.environment
+    // socketPathEnvironment
+    // {
+      CAPSULE_NIX_MANAGED = "1";
+    };
   environmentList = lib.mapAttrsToList (name: value: "${name}=${value}") daemonEnvironment;
 in
 {
@@ -65,6 +71,8 @@ in
     })
 
     (lib.mkIf (cfg.enable && cfg.daemon.enable) {
+      home.sessionVariables = socketPathEnvironment;
+
       home.activation.createCapsuleRuntimeDir = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
         run mkdir -m 700 -p $VERBOSE_ARG ${lib.escapeShellArg socketDir}
       '';

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -1,0 +1,124 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.capsule;
+  inherit (pkgs.stdenv.hostPlatform) isDarwin isLinux;
+  socketDir = builtins.dirOf cfg.daemon.socketPath;
+  daemonEnvironment = cfg.daemon.environment // {
+    CAPSULE_NIX_MANAGED = "1";
+  };
+  environmentList = lib.mapAttrsToList (name: value: "${name}=${value}") daemonEnvironment;
+in
+{
+  options.programs.capsule = {
+    enable = lib.mkEnableOption "capsule prompt engine";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.callPackage ../package.nix { };
+      defaultText = lib.literalExpression "pkgs.callPackage ./nix/package.nix { }";
+      description = "capsule package to install.";
+    };
+
+    daemon = {
+      enable = lib.mkEnableOption "capsule daemon managed by Home Manager";
+
+      socketPath = lib.mkOption {
+        type = lib.types.str;
+        default = "${config.home.homeDirectory}/.capsule/capsule.sock";
+        defaultText = lib.literalExpression ''"${config.home.homeDirectory}/.capsule/capsule.sock"'';
+        description = "Unix-domain socket path used by capsule's shell relay.";
+      };
+
+      environment = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = {
+          XDG_CONFIG_HOME = config.xdg.configHome;
+        };
+        defaultText = lib.literalExpression "{ XDG_CONFIG_HOME = config.xdg.configHome; }";
+        description = "Environment variables passed to the socket-activated daemon.";
+      };
+    };
+  };
+
+  config = lib.mkMerge [
+    {
+      assertions = [
+        {
+          assertion = !cfg.daemon.enable || cfg.enable;
+          message = "programs.capsule.daemon.enable requires programs.capsule.enable.";
+        }
+        {
+          assertion = !cfg.daemon.enable || isDarwin || isLinux;
+          message = "capsule daemon management is only supported on Darwin and Linux.";
+        }
+      ];
+    }
+
+    (lib.mkIf cfg.enable {
+      home.packages = [ cfg.package ];
+    })
+
+    (lib.mkIf (cfg.enable && cfg.daemon.enable) {
+      home.activation.createCapsuleRuntimeDir = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        run mkdir -m 700 -p $VERBOSE_ARG ${lib.escapeShellArg socketDir}
+      '';
+    })
+
+    (lib.mkIf (cfg.enable && cfg.daemon.enable && isLinux) {
+      systemd.user.services.capsule = {
+        Unit = {
+          Description = "capsule prompt daemon";
+          Requires = [ "capsule.socket" ];
+          After = [ "capsule.socket" ];
+        };
+
+        Service = {
+          Type = "simple";
+          ExecStart = "${lib.getExe cfg.package} daemon";
+          Environment = environmentList;
+        };
+      };
+
+      systemd.user.sockets.capsule = {
+        Unit = {
+          Description = "capsule prompt daemon socket";
+        };
+
+        Socket = {
+          ListenStream = cfg.daemon.socketPath;
+          SocketMode = "0700";
+          DirectoryMode = "0700";
+        };
+
+        Install = {
+          WantedBy = [ "sockets.target" ];
+        };
+      };
+    })
+
+    (lib.mkIf (cfg.enable && cfg.daemon.enable && isDarwin) {
+      launchd.agents.capsule = {
+        enable = true;
+        domain = lib.mkDefault "gui";
+        config = {
+          Label = "com.github.shuymn.capsule";
+          ProgramArguments = [
+            (lib.getExe cfg.package)
+            "daemon"
+          ];
+          EnvironmentVariables = daemonEnvironment;
+          Sockets.Listeners = {
+            SockPathName = cfg.daemon.socketPath;
+            SockPathMode = 448;
+          };
+        };
+      };
+    })
+  ];
+}

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -35,7 +35,7 @@ in
       enable = lib.mkEnableOption "capsule daemon managed by Home Manager";
 
       socketPath = lib.mkOption {
-        type = lib.types.str;
+        type = lib.types.nonEmptyStr;
         default = "${config.home.homeDirectory}/.capsule/capsule.sock";
         defaultText = lib.literalExpression ''"${config.home.homeDirectory}/.capsule/capsule.sock"'';
         description = "Unix-domain socket path used by capsule's shell relay.";

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -1,0 +1,83 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.capsule;
+  daemonEnvironment = cfg.daemon.environment // {
+    CAPSULE_NIX_MANAGED = "1";
+  };
+  environmentList = lib.mapAttrsToList (name: value: "${name}=${value}") daemonEnvironment;
+in
+{
+  options.programs.capsule = {
+    enable = lib.mkEnableOption "capsule prompt engine";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.callPackage ../package.nix { };
+      defaultText = lib.literalExpression "pkgs.callPackage ./nix/package.nix { }";
+      description = "capsule package to install.";
+    };
+
+    daemon = {
+      enable = lib.mkEnableOption "capsule daemon managed as a systemd user service";
+
+      socketPath = lib.mkOption {
+        type = lib.types.str;
+        default = "%h/.capsule/capsule.sock";
+        description = "Unix-domain socket path used by capsule's shell relay. systemd expands %h to the user's home directory.";
+      };
+
+      environment = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+        example = lib.literalExpression ''{ XDG_CONFIG_HOME = "%h/.config"; }'';
+        description = "Environment variables passed to the socket-activated daemon.";
+      };
+    };
+  };
+
+  config = lib.mkMerge [
+    {
+      assertions = [
+        {
+          assertion = !cfg.daemon.enable || cfg.enable;
+          message = "programs.capsule.daemon.enable requires programs.capsule.enable.";
+        }
+      ];
+    }
+
+    (lib.mkIf cfg.enable {
+      environment.systemPackages = [ cfg.package ];
+    })
+
+    (lib.mkIf (cfg.enable && cfg.daemon.enable) {
+      systemd.user.services.capsule = {
+        description = "capsule prompt daemon";
+        requires = [ "capsule.socket" ];
+        after = [ "capsule.socket" ];
+
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = "${lib.getExe cfg.package} daemon";
+          Environment = environmentList;
+        };
+      };
+
+      systemd.user.sockets.capsule = {
+        description = "capsule prompt daemon socket";
+        wantedBy = [ "sockets.target" ];
+        listenStreams = [ cfg.daemon.socketPath ];
+
+        socketConfig = {
+          SocketMode = "0700";
+          DirectoryMode = "0700";
+        };
+      };
+    })
+  ];
+}

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -7,9 +7,18 @@
 
 let
   cfg = config.programs.capsule;
-  daemonEnvironment = cfg.daemon.environment // {
-    CAPSULE_NIX_MANAGED = "1";
+  socketPathEnvironment = {
+    CAPSULE_SOCKET_PATH = cfg.daemon.socketPath;
   };
+  sessionSocketPathEnvironment = {
+    CAPSULE_SOCKET_PATH = builtins.replaceStrings [ "%h" ] [ "$HOME" ] cfg.daemon.socketPath;
+  };
+  daemonEnvironment =
+    cfg.daemon.environment
+    // socketPathEnvironment
+    // {
+      CAPSULE_NIX_MANAGED = "1";
+    };
   environmentList = lib.mapAttrsToList (name: value: "${name}=${value}") daemonEnvironment;
 in
 {
@@ -27,7 +36,7 @@ in
       enable = lib.mkEnableOption "capsule daemon managed as a systemd user service";
 
       socketPath = lib.mkOption {
-        type = lib.types.str;
+        type = lib.types.nonEmptyStr;
         default = "%h/.capsule/capsule.sock";
         description = "Unix-domain socket path used by capsule's shell relay. systemd expands %h to the user's home directory.";
       };
@@ -56,6 +65,8 @@ in
     })
 
     (lib.mkIf (cfg.enable && cfg.daemon.enable) {
+      environment.sessionVariables = sessionSocketPathEnvironment;
+
       systemd.user.services.capsule = {
         description = "capsule prompt daemon";
         requires = [ "capsule.socket" ];

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -20,8 +20,7 @@ rustPlatform.buildRustPackage {
     "capsule-cli"
   ];
   cargoTestFlags = [
-    "--package"
-    "capsule-cli"
+    "--workspace"
   ];
 
   nativeCheckInputs = [

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  rustPlatform,
+  git,
+  zsh,
+}:
+
+let
+  manifest = builtins.fromTOML (builtins.readFile ../Cargo.toml);
+in
+rustPlatform.buildRustPackage {
+  pname = "capsule";
+  version = manifest.workspace.package.version;
+
+  src = lib.cleanSource ../.;
+
+  cargoLock.lockFile = ../Cargo.lock;
+  cargoBuildFlags = [
+    "--package"
+    "capsule-cli"
+  ];
+  cargoTestFlags = [
+    "--package"
+    "capsule-cli"
+  ];
+
+  nativeCheckInputs = [
+    git
+    zsh
+  ];
+
+  meta = {
+    description = "Prompt engine for zsh";
+    homepage = "https://github.com/shuymn/capsule";
+    license = lib.licenses.mit;
+    mainProgram = "capsule";
+    platforms = lib.platforms.darwin ++ lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Summary

- Add Nix flake with declarative daemon modules for NixOS, Home Manager, and nix-darwin
- Add Cachix binary cache support for pre-built binaries
- Add CI workflow for flake checks
- Guard imperative `capsule daemon install/uninstall` against Nix-managed service definitions
- Clear git-local environment variables in subprocess to prevent GIT_DIR leakage from parent shells

## Why

Nix users can now consume capsule as a flake with declarative service management instead of running `capsule daemon install`. The `CAPSULE_NIX_MANAGED=1` environment marker in service definitions prevents accidental imperative modification when Nix manages the daemon. Clearing git-local env vars fixes a correctness issue where `GIT_DIR`/`GIT_WORK_TREE` from the parent shell leaks into git subprocesses and causes wrong repository detection in the prompt.

## What changed

**Nix flake** (new): `flake.nix`, `nix/package.nix`, `nix/modules/{nixos,home-manager,darwin}.nix` — provides a buildable package, app entrypoint, and a NixOS/Home Manager/nix-darwin module for declarative daemon management.

**Cachix binary cache**: `nixConfig` in `flake.nix` points to `shuymn.cachix.org`; release workflow pushes package outputs after build.

**Release workflow refactor**: Simplified tag workflow (push-based trigger replacing CI-triggered workflow_run), removed artifact attestation and sha256 checksums, streamlined release creation. The release job now depends on the new nix-cache job.

**Nix-managed daemon guards** (Rust): `is_nix_managed_definition()` detects service definitions by Nix store path, symlink target, or `CAPSULE_NIX_MANAGED` marker. `capsule daemon install/uninstall` and auto-reconnection in `connect.rs` all bail with a clear message when the daemon is Nix-managed.

**Git subprocess env isolation** (Rust): New `clear_git_local_env!` macro strips 14 GIT_* vars from subprocess env. Includes regression test that spawns itself with `GIT_DIR`/`GIT_WORK_TREE` set to a polluted repo and verifies status resolves to the actual cwd.

**Documentation**: README now has separate Homebrew and Nix sections with usage examples for all three Nix module systems.

## Testing

- `task nix:check` passes (flake evaluation, package builds, app runs)
- `task test` passes (existing + new regression tests for git env isolation and Nix-managed detection)
- `task lint` passes
- Module evaluations tested via `flake.nix` `checks` output for NixOS, Home Manager, and nix-darwin configs
