### PR TITLE
build(release): treat feat commits as minor bumps before 1.0

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -5,6 +5,7 @@ Use this workflow to prepare, approve, promote, and distribute a capsule release
 ## Release contract
 
 - Use `[workspace.package].version` in `Cargo.toml` as the only product version source.
+- Treat `feat` commits as minor increments even before 1.0; keep `features_always_increment_minor = true` in the candidate-producer configuration.
 - Use the merged Release PR's head commit as `candidate_sha`. Tag the reviewed candidate tree, not the latest `main` commit or the merge commit.
 - Merge Release PRs with a merge commit. Promotion rejects a candidate that is not reachable from `main`; squash or rebase merging makes the original reviewed head unreachable.
 - Derive the release tag as `v{version}`.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,6 +4,7 @@ publish = false
 git_release_enable = false
 git_tag_enable = false
 release_always = false
+features_always_increment_minor = true
 
 [[package]]
 name = "capsule-cli"


### PR DESCRIPTION
## Summary

Configure `release-plz` to treat `feat` commits as minor version bumps even before reaching 1.0, so the pre-1.0 semver convention (where `feat` increments the minor version) is respected.

## Why

Pre-1.0 releases conventionally use semver differently: a `feat` commit should bump the minor component (e.g., `0.2.0` → `0.3.0`), not the patch. This aligns `release-plz` behavior with that convention.

## Testing

- `release-plz.toml` is validated by the `release:check` task (part of `task check`)
- The change is purely declarative — the existing test suite and release contract tests pass
